### PR TITLE
RSS: Avoid empty content element if there is no comment / annotation

### DIFF
--- a/templates/pages/list-by-sciety-list-id.atom.xml
+++ b/templates/pages/list-by-sciety-list-id.atom.xml
@@ -12,11 +12,13 @@
         <published>{{ item.created_at_isoformat }}</published>
         <summary>{{ item.article_meta.article_title }}</summary>
         <id>doi:{{ item.article_doi }}</id>
+        {% if item.comment %}
         <content type="xhtml">
             <div xmlns="http://www.w3.org/1999/xhtml">
                 <p>{{ item.comment }}</p>
             </div>
         </content>
+        {% endif %}
         <author>
             <name>{{ list_summary_data.owner.display_name }}</name>
         </author>


### PR DESCRIPTION
Avoid this (where `None` would be the comment / annotation):

```xml
        <content type="xhtml">
            <div xmlns="http://www.w3.org/1999/xhtml">
                <p>None</p>
            </div>
        </content>
```