### PR TITLE
RSS: Added abstract as content and made comment summary

### DIFF
--- a/templates/pages/list-by-sciety-list-id.atom.xml
+++ b/templates/pages/list-by-sciety-list-id.atom.xml
@@ -22,6 +22,11 @@
 
         {% if item.article_meta.abstract %}
         <content type="xhtml">
+            {% if item.comment %}
+            <div xmlns="http://www.w3.org/1999/xhtml" class="comment">
+                <p>{{ item.comment }}</p>
+            </div>
+            {% endif %}
             <div xmlns="http://www.w3.org/1999/xhtml" class="article-abstract">
                 <h2>Abstract</h2>
                 <div>

--- a/templates/pages/list-by-sciety-list-id.atom.xml
+++ b/templates/pages/list-by-sciety-list-id.atom.xml
@@ -13,12 +13,24 @@
         <summary>{{ item.article_meta.article_title }}</summary>
         <id>doi:{{ item.article_doi }}</id>
         {% if item.comment %}
-        <content type="xhtml">
-            <div xmlns="http://www.w3.org/1999/xhtml">
+        <summary type="xhtml">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="comment">
                 <p>{{ item.comment }}</p>
+            </div>
+        </summary>
+        {% endif %}
+
+        {% if item.article_meta.abstract %}
+        <content type="xhtml">
+            <div xmlns="http://www.w3.org/1999/xhtml" class="article-abstract">
+                <h2>Abstract</h2>
+                <div>
+                    {{ item.article_meta.abstract | sanitize }}
+                </div>
             </div>
         </content>
         {% endif %}
+
         <author>
             <name>{{ list_summary_data.owner.display_name }}</name>
         </author>


### PR DESCRIPTION
For example:

```xml
        <summary type="xhtml">
            <div xmlns="http://www.w3.org/1999/xhtml" class="comment">
                <p>Really well written article showing for the first time that non-muscle myosin 2, largely thought to be contractile rather than processive, has the ability to move toward the leading edge of cells on parallel actin bundles (against retrograde actin flow). </p>
            </div>
        </summary>
        

        
        <content type="xhtml">
            
            <div xmlns="http://www.w3.org/1999/xhtml" class="comment">
                <p>Really well written article showing for the first time that non-muscle myosin 2, largely thought to be contractile rather than processive, has the ability to move toward the leading edge of cells on parallel actin bundles (against retrograde actin flow). </p>
            </div>
            
            <div xmlns="http://www.w3.org/1999/xhtml" class="article-abstract">
                <h2>Abstract</h2>
                <div>
                    <p>Directed transport of cellular components is often dependent on the processive movements of cytoskeletal motors. Myosin 2 motors predominantly engage actin filaments of opposing orientation to drive contractile events, and are therefore not traditionally viewed as processive. However, recent<i>in vitro</i>experiments with purified non-muscle myosin 2 (NM2) demonstrated myosin 2 filaments could move processively. Here, we establish processivity as a cellular property of NM2. Processive runs in central nervous system-derived CAD cells are most apparent as processive movements on bundled actin in protrusions that terminate at the leading edge. We find that processive velocities<i>in vivo</i>are consistent with<i>in vitro</i>measurements. NM2 makes these processive runs in its filamentous form against lamellipodia retrograde flow, though anterograde movement can still occur in the absence of actin dynamics. Comparing the processivity of NM2 isoforms, we find that NM2A moves slightly faster than NM2B. Finally, we demonstrate that this is not a cell-specific property, as we observe processive-like movements of NM2 in the lamella and subnuclear stress fibers of fibroblasts. Collectively, these observations further broaden NM2 functionality and the biological processes in which the already ubiquitous motor can contribute.</p>
                </div>
            </div>
        </content>
```