### PR TITLE
Display error message in article card if title couldn't be retrieved

### DIFF
--- a/templates/macros/article.html
+++ b/templates/macros/article.html
@@ -13,7 +13,11 @@
                 >
                 {% endif %}
 
+                {% if item.article_meta.article_title %}
                 <h3 class="article-card__title"><a class="article-card__link" href="/articles/by?article_doi={{ item.article_doi }}">{{ item.article_meta.article_title | sanitize }}</a></h3>
+                {% else %}
+                <h3 class="article-card__title"><a class="article-card__link" href="/articles/by?article_doi={{ item.article_doi }}">Error retrieving metadata for {{ item.article_doi }}</a></h3>
+                {% endif %}
 
                 <div class="hidden" id="article-card-author-list-{{ item.article_doi }}">This article's authors</div>
                 {% if item.article_meta.author_name_list %}


### PR DESCRIPTION
For example recommendations for `10.1101/2021.04.20.440368` include `10.1101/2023.02.28.530451` which we currently can't get metadata for.