### PR TITLE
Move to python-slim image and don't keep PIP cache in docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM python:3.8 AS base
+FROM python:3.8-slim AS base
 
 USER root
 
 WORKDIR /app/sciety-labs
 
+ENV PIP_NO_CACHE_DIR=1
 COPY requirements.build.txt ./
 RUN pip install --disable-pip-version-check -r requirements.build.txt
 


### PR DESCRIPTION
fixes https://github.com/elifesciences/issues/issues/8214

These changes combined would make shrink the image size from ~1.1GB to ~321MB.

Note: I have not been able to run test these changes as I don't have gcloud credentials. It does build fine though.