### PR TITLE
Use accepted as published date if available and more recent

### DIFF
--- a/sciety_labs/providers/crossref.py
+++ b/sciety_labs/providers/crossref.py
@@ -82,6 +82,14 @@ def get_optional_date_from_date_field(date_field: Optional[dict]) -> Optional[da
     return get_optional_date_from_date_parts(date_field.get('date-parts'))
 
 
+def get_published_date_from_crossref_metadata(crossref_metadata: dict) -> Optional[date]:
+    accepted_date = get_optional_date_from_date_field(crossref_metadata.get('accepted'))
+    published_date = get_optional_date_from_date_field(crossref_metadata.get('published'))
+    if accepted_date and published_date:
+        return max(accepted_date, published_date)
+    return accepted_date or published_date
+
+
 def get_article_metadata_from_crossref_metadata(
     doi: str,
     crossref_metadata: dict
@@ -94,8 +102,8 @@ def get_article_metadata_from_crossref_metadata(
             get_author_name_from_crossref_metadata_author_dict(author_dict)
             for author_dict in crossref_metadata.get('author', [])
         ],
-        published_date=get_optional_date_from_date_field(
-            crossref_metadata.get('published')
+        published_date=get_published_date_from_crossref_metadata(
+            crossref_metadata
         )
     )
 

--- a/tests/unit_tests/providers/crossref_test.py
+++ b/tests/unit_tests/providers/crossref_test.py
@@ -134,6 +134,28 @@ class TestGetArticleMetadataFromCrossrefMetadata:
         )
         assert result.published_date == date(2001, 2, 3)
 
+    def test_should_prefer_accepted_date_as_published_date_if_available_and_later(self):
+        result = get_article_metadata_from_crossref_metadata(
+            DOI_1,
+            {
+                **CROSSREF_RESPONSE_MESSAGE_1,
+                'published': {'date-parts': [[2001, 2, 3]]},
+                'accepted': {'date-parts': [[2002, 2, 3]]}
+            }
+        )
+        assert result.published_date == date(2002, 2, 3)
+
+    def test_should_prefer_published_date_as_published_date_if_available_and_later(self):
+        result = get_article_metadata_from_crossref_metadata(
+            DOI_1,
+            {
+                **CROSSREF_RESPONSE_MESSAGE_1,
+                'published': {'date-parts': [[2002, 2, 3]]},
+                'accepted': {'date-parts': [[2001, 2, 3]]}
+            }
+        )
+        assert result.published_date == date(2002, 2, 3)
+
 
 class TestGetFilterParameterForDois:
     def test_should_return_comma_separated_dois_with_prefix(self):


### PR DESCRIPTION
Example: 10.1101/2022.10.27.514096
Should be 22 Feb 2023, but it was showing the Crossref posted/created date from 2022.

Crossref has the following fields:

| name | value |
| --------- | ------- |
| created | 2022-10-28 |
| published | 2022-10-28 |
| issued | 2022-10-28 |
| accepted | 2023-02-22 |
| deposited | 2023-02-25 |
| indexed | 2023-03-08 |