### PR TITLE
Support incorrectly recorded evaluation erased event

### DIFF
--- a/sciety_labs/main.py
+++ b/sciety_labs/main.py
@@ -600,6 +600,7 @@ def create_app():  # pylint: disable=too-many-locals, too-many-statements
             )
         LOGGER.info('article_meta=%r', article_meta)
 
+        article_stats = evaluation_stats_model.get_article_stats_by_article_doi(article_doi)
         article_images = google_sheet_article_image_provider.get_article_images_by_doi(article_doi)
 
         try:
@@ -638,6 +639,7 @@ def create_app():  # pylint: disable=too-many-locals, too-many-statements
                     article_meta.abstract
                 ),
                 'article_meta': article_meta,
+                'article_stats': article_stats,
                 'article_images': article_images,
                 'article_recommendation_list': article_recommendation_with_article_meta,
                 'article_recommendation_url': article_recommendation_url

--- a/sciety_labs/models/evaluation.py
+++ b/sciety_labs/models/evaluation.py
@@ -47,7 +47,8 @@ class ScietyEventEvaluationStatsModel:
         LOGGER.debug('removing evaluation with locator: %r', evaluation_locator)
         evaluation_reference = self._evaluation_reference_by_evaluation_locator[evaluation_locator]
         LOGGER.debug('removing evaluation: %r', evaluation_reference)
-        self._evaluation_reference_by_article_id[evaluation_reference.article_id].remove(
+        normalized_article_id = get_normalized_article_id(evaluation_reference.article_id)
+        self._evaluation_reference_by_article_id[normalized_article_id].remove(
             evaluation_reference
         )
 

--- a/sciety_labs/models/evaluation.py
+++ b/sciety_labs/models/evaluation.py
@@ -71,6 +71,13 @@ class ScietyEventEvaluationStatsModel:
             )
         )
 
+    def get_article_stats_by_article_doi(self, article_doi: str) -> ArticleStats:
+        return ArticleStats(
+            evaluation_count=self.get_evaluation_count_by_article_id(
+                DOI_ARTICLE_ID_PREFIX + article_doi
+            )
+        )
+
     def iter_article_mention_with_article_stats(
         self,
         article_mention_iterable: Iterable[ArticleMentionT]
@@ -79,10 +86,8 @@ class ScietyEventEvaluationStatsModel:
             cast(
                 ArticleMentionT,
                 article_mention._replace(
-                    article_stats=ArticleStats(
-                        evaluation_count=self.get_evaluation_count_by_article_id(
-                            DOI_ARTICLE_ID_PREFIX + article_mention.article_doi
-                        )
+                    article_stats=self.get_article_stats_by_article_doi(
+                        article_mention.article_doi
                     )
                 )
             )

--- a/sciety_labs/providers/sql/get_sciety_events.sql
+++ b/sciety_labs/providers/sql/get_sciety_events.sql
@@ -27,6 +27,9 @@ WHERE
     )
     AND NOT event.is_duplicate_event
   ) OR (
-    event.normalized_event_name = 'EvaluationRecorded'
+    event.normalized_event_name IN (
+        'EvaluationRecorded',
+        'IncorrectlyRecordedEvaluationErased'
+    )
   )
 ORDER BY event_timestamp

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -153,3 +153,7 @@
     font-size: 1.2em;
     color: #c44;
 }
+
+section.article-stats {
+    margin-top: 0.5em;
+}

--- a/templates/pages/article-by-article-doi.html
+++ b/templates/pages/article-by-article-doi.html
@@ -1,5 +1,6 @@
 {% from 'macros/page.html' import render_page with context %}
 {% from 'macros/article.html' import render_article_list_content with context %}
+{% from 'macros/date.html' import render_optional_date_value_with_label %}
 {% call render_page() %}
     <main class="page-content" id="mainContent">
       
@@ -22,6 +23,16 @@
                     {% endfor %}
                 </ol>
                 {% endif %}
+
+                <section class="article-stats">
+                    <div class="article-card__meta">
+                    {% if article_stats %}
+                    <span class="visually-hidden">This article has </span><span>{{ article_stats.evaluation_count }} evaluations</span>
+                    {% endif %}
+                    {{ render_optional_date_value_with_label('Published on', article_meta.published_date) }}
+                    {{ render_optional_date_value_with_label('Added on', created_at_timestamp) }}
+                    </div>
+                </section>
             </header>
 
             <div class="article-actions">

--- a/tests/unit_tests/models/evaluation_test.py
+++ b/tests/unit_tests/models/evaluation_test.py
@@ -40,6 +40,18 @@ class TestScietyEventEvaluationStatsModel:
         }])
         assert model.get_evaluation_count_by_article_id(ARTICLE_ID_1) == 2
 
+    def test_should_not_count_incorrectly_recorded_evaluations(self):
+        model = ScietyEventEvaluationStatsModel([{
+            **EVALUATION_RECORDED_EVENT_1,
+            'evaluation_locator': EVALUATION_LOCATOR_1
+        }, {
+            **EVALUATION_RECORDED_EVENT_1,
+            'event_name': 'IncorrectlyRecordedEvaluationErased',
+            'evaluation_locator': EVALUATION_LOCATOR_1,
+            'article_id': None
+        }])
+        assert model.get_evaluation_count_by_article_id(ARTICLE_ID_1) == 0
+
     def test_should_match_article_id_ignoring_case(self):
         model = ScietyEventEvaluationStatsModel([{
             **EVALUATION_RECORDED_EVENT_1,

--- a/tests/unit_tests/models/evaluation_test.py
+++ b/tests/unit_tests/models/evaluation_test.py
@@ -63,3 +63,16 @@ class TestScietyEventEvaluationStatsModel:
             'evaluation_locator': EVALUATION_LOCATOR_2
         }])
         assert model.get_evaluation_count_by_article_id('doi:10.1234/doI_1') == 2
+
+    def test_should_match_article_id_ignoring_case_when_erasing_evaluation(self):
+        model = ScietyEventEvaluationStatsModel([{
+            **EVALUATION_RECORDED_EVENT_1,
+            'article_id': 'doi:10.1234/Doi_1',
+            'evaluation_locator': EVALUATION_LOCATOR_1
+        }, {
+            **EVALUATION_RECORDED_EVENT_1,
+            'event_name': 'IncorrectlyRecordedEvaluationErased',
+            'evaluation_locator': EVALUATION_LOCATOR_1,
+            'article_id': None
+        }])
+        assert model.get_evaluation_count_by_article_id(ARTICLE_ID_1) == 0


### PR DESCRIPTION
This also added article stats to the article page. Which makes it easier to test.
(As the evaluations were only available on article cards as a count)