### PR TITLE
Added generic search feed page description

### DIFF
--- a/sciety_labs/app/routers/search.py
+++ b/sciety_labs/app/routers/search.py
@@ -233,6 +233,9 @@ def create_search_router(  # pylint: disable=too-many-statements
                     f'Search feed for {search_parameters.query}'
                     if search_parameters.query else 'Search feed'
                 ),
+                'page_description': (
+                    'Keep up to date with the latest preprint activity'
+                ),
                 'rss_url': get_rss_url(request)
             },
             status_code=search_result_page.status_code

--- a/sciety_labs/app/routers/search.py
+++ b/sciety_labs/app/routers/search.py
@@ -278,7 +278,10 @@ def create_search_router(  # pylint: disable=too-many-statements
                 'page_title': (
                     f'Search feed for {search_parameters.query}'
                     if search_parameters.query else 'Search feed'
-                )
+                ),
+                'page_description': (
+                    'Keep up to date with the latest preprint activity'
+                ),
             },
             media_type=AtomResponse.media_type,
             status_code=search_result_page.status_code

--- a/templates/pages/search-feed.atom.xml
+++ b/templates/pages/search-feed.atom.xml
@@ -3,6 +3,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
     <title type="html">Search feed for {{ query }}</title>
+    <subtitle type="html">{{ page_description }}</subtitle>
     <link href="{{ request.url }}" rel="self" />
     <updated>{{ last_updated_timestamp | timestamp_isoformat }}</updated>
     <id>tag:sciety-labs,2023-04-20:search-parameters-hash={{ search_parameters_hash }}</id>


### PR DESCRIPTION
Added page description to search feeds:
>  Keep up to date with the latest preprint activity

This will then be displayed in when sharing the link for example.