### PR TITLE
Revert "Bump types-requests from 2.31.0.7 to 2.31.0.8"

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -6,4 +6,4 @@ mypy==1.5.1
 httpx==0.25.0
 types-bleach==6.0.0.5
 types-PyYAML==6.0.12.12
-types-requests==2.31.0.8
+types-requests==2.31.0.7


### PR DESCRIPTION
Reverts sciety/sciety-labs#216

This is causing dependency issues when installing dependencies together (but currently ignored by docker build):

```
ERROR: Cannot install -r requirements.dev.txt (line 9), -r requirements.txt (line 12), -r requirements.txt (line 13) and -r requirements.txt (line 8) because these package versions have conflicting dependencies.

The conflict is caused by:
    opensearch-py 2.3.1 depends on urllib3<2 and >=1.21.1
    requests 2.31.0 depends on urllib3<3 and >=1.21.1
    requests-cache 1.1.0 depends on urllib3>=1.25.5
    types-requests 2.31.0.8 depends on urllib3>=2
```