### PR TITLE
Fix dependency issues related to urllib3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,19 @@ WORKDIR /app/sciety-labs
 
 ENV PIP_NO_CACHE_DIR=1
 COPY requirements.build.txt ./
-RUN pip install --disable-pip-version-check -r requirements.build.txt
+RUN pip install --disable-pip-version-check \
+    -r requirements.build.txt
 
 COPY requirements.txt ./
-RUN pip install --disable-pip-version-check -r requirements.txt
+RUN pip install --disable-pip-version-check \
+    -r requirements.build.txt \
+    -r requirements.txt
 
 COPY requirements.dev.txt ./
-RUN pip install --disable-pip-version-check -r requirements.dev.txt
+RUN pip install --disable-pip-version-check \
+    -r requirements.build.txt \
+    -r requirements.txt \
+    -r requirements.dev.txt
 
 COPY sciety_labs ./sciety_labs
 COPY static ./static

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -6,4 +6,4 @@ mypy==1.5.1
 httpx==0.25.0
 types-bleach==6.0.0.5
 types-PyYAML==6.0.12.12
-types-requests==2.31.0.8
+types-requests==2.30.0.0


### PR DESCRIPTION
When installing a virtual env, the following dependency issue is shown:

```
ERROR: Cannot install -r requirements.dev.txt (line 9), -r requirements.txt (line 12), -r requirements.txt (line 13) and -r requirements.txt (line 8) because these package versions have conflicting dependencies.

The conflict is caused by:
    opensearch-py 2.3.1 depends on urllib3<2 and >=1.21.1
    requests 2.31.0 depends on urllib3<3 and >=1.21.1
    requests-cache 1.1.0 depends on urllib3>=1.25.5
    types-requests 2.31.0.8 depends on urllib3>=2
```

This isn't currently shown in the Docker build because dev dependencies are installed separately.