### PR TITLE
OpenSearch: Provide Evaluated Related Articles

### DIFF
--- a/sciety_labs/app/routers/api/app.py
+++ b/sciety_labs/app/routers/api/app.py
@@ -13,7 +13,7 @@ def create_api_app(
     app_providers_and_models: AppProvidersAndModels,
     app_update_manager: AppUpdateManager
 ) -> fastapi.FastAPI:
-    app = fastapi.FastAPI()
+    app = fastapi.FastAPI(title='Sciety Labs API', version='1.0.0')
 
     app.include_router(create_api_maintenance_router(
         app_update_manager=app_update_manager

--- a/sciety_labs/app/routers/api/article_recommendation.py
+++ b/sciety_labs/app/routers/api/article_recommendation.py
@@ -216,12 +216,21 @@ def create_api_article_recommendation_router(
                 Not part of S2, and only working with OpenSearch.
                 '''
             )
+        ),
+        published_within_last_n_days: int = fastapi.Query(
+            alias='_published_within_last_n_days',
+            default=60,
+            description=textwrap.dedent(
+                '''
+                Only consider papers published within the last *n* days.
+                '''
+            )
         )
     ):
         fields_set = set(fields.split(','))
         filter_parameters = ArticleRecommendationFilterParameters(
             exclude_article_dois={article_doi},
-            from_publication_date=date.today() - timedelta(days=60),
+            from_publication_date=date.today() - timedelta(days=published_within_last_n_days),
             evaluated_only=evaluated_only
         )
         try:

--- a/sciety_labs/app/routers/api/article_recommendation.py
+++ b/sciety_labs/app/routers/api/article_recommendation.py
@@ -44,6 +44,7 @@ class PaperDict(TypedDict):
     title: NotRequired[Optional[str]]
     publicationDate: NotRequired[Optional[str]]
     authors: NotRequired[Optional[Sequence[AuthorDict]]]
+    _evaluationCount: NotRequired[Optional[int]]
 
 
 class RecommendationResponseDict(TypedDict):
@@ -80,6 +81,12 @@ def get_s2_recommended_paper_response_for_article_recommendation(
             'authors': get_s2_recommended_author_list_for_author_names(
                 article_meta.author_name_list
             )
+        }
+    article_stats = article_recommendation.article_stats
+    if article_stats:
+        response = {
+            **response,
+            '_evaluationCount': article_stats.evaluation_count
         }
     if fields:
         response = cast(
@@ -129,6 +136,8 @@ def create_api_article_recommendation_router(
             - Only preprints are returned
             - Related articles can be provided for almost any DOI with title and abstract in Crossref
             - The publication date is more accurate
+
+            Parameters and fields starting with underscore are specific to this API (not like S2).
             '''  # noqa pylint: disable=line-too-long
         ),
         response_model=RecommendationResponseDict,
@@ -183,6 +192,7 @@ def create_api_article_recommendation_router(
                 - `title`
                 - `publicationDate`
                 - `authors` (only containing `name`)
+                - `_evaluationCount`
                 '''
             )
         ),

--- a/sciety_labs/app/routers/api/article_recommendation.py
+++ b/sciety_labs/app/routers/api/article_recommendation.py
@@ -12,6 +12,7 @@ import requests
 
 from sciety_labs.app.app_providers_and_models import AppProvidersAndModels
 from sciety_labs.app.utils.recommendation import (
+    DEFAULT_PUBLISHED_WITHIN_LAST_N_DAYS_BY_EVALUATED_ONLY,
     get_article_recommendation_list_for_article_dois
 )
 from sciety_labs.providers.article_recommendation import (
@@ -29,12 +30,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 DEFAULT_LIKE_S2_RECOMMENDATION_FIELDS = {'externalIds'}
-
-
-DEFAULT_PUBLISHED_WITHIN_LAST_N_DAYS_BY_EVALUATED_ONLY = {
-    False: 60,
-    True: 365
-}
 
 
 class ExternalIdsDict(TypedDict):

--- a/sciety_labs/app/routers/api/article_recommendation.py
+++ b/sciety_labs/app/routers/api/article_recommendation.py
@@ -183,7 +183,7 @@ def create_api_article_recommendation_router(
                 The DOI to provide paper recommendations for.
                 '''
             ),
-            example='10.1101/2022.08.08.502889'
+            example='10.1101/2022.08.08.502889'  # Note: deprecated but appears in /docs and /redoc
         ),
         fields: str = fastapi.Query(
             default=','.join(sorted(DEFAULT_LIKE_S2_RECOMMENDATION_FIELDS)),
@@ -198,7 +198,12 @@ def create_api_article_recommendation_router(
                 - `_evaluationCount`
                 - `_score`
                 '''
-            )
+            ),
+            examples=[  # Note: These only seem to appear in /redoc
+                'externalIds',
+                'externalIds,title,publicationDate,authors',
+                'externalIds,title,publicationDate,authors,_evaluationCount,_score'
+            ]
         ),
         limit: Optional[int] = fastapi.Query(
             default=None,

--- a/sciety_labs/app/routers/api/article_recommendation.py
+++ b/sciety_labs/app/routers/api/article_recommendation.py
@@ -45,6 +45,7 @@ class PaperDict(TypedDict):
     publicationDate: NotRequired[Optional[str]]
     authors: NotRequired[Optional[Sequence[AuthorDict]]]
     _evaluationCount: NotRequired[Optional[int]]
+    _score: NotRequired[Optional[float]]
 
 
 class RecommendationResponseDict(TypedDict):
@@ -70,7 +71,8 @@ def get_s2_recommended_paper_response_for_article_recommendation(
     response: PaperDict = {
         'externalIds': {
             'DOI': article_recommendation.article_doi
-        }
+        },
+        '_score': article_recommendation.score
     }
     article_meta = article_recommendation.article_meta
     if article_meta:
@@ -193,6 +195,7 @@ def create_api_article_recommendation_router(
                 - `publicationDate`
                 - `authors` (only containing `name`)
                 - `_evaluationCount`
+                - `_score`
                 '''
             )
         ),

--- a/sciety_labs/app/routers/api/article_recommendation.py
+++ b/sciety_labs/app/routers/api/article_recommendation.py
@@ -139,6 +139,8 @@ def create_api_article_recommendation_router(
             - Only preprints are returned
             - Related articles can be provided for almost any DOI with title and abstract in Crossref
             - The publication date is more accurate
+            - Ability filter by evaluated preprints
+            - Ability to increase the date range
 
             Parameters and fields starting with underscore are specific to this API (not like S2).
             '''  # noqa pylint: disable=line-too-long

--- a/sciety_labs/app/routers/api/article_recommendation.py
+++ b/sciety_labs/app/routers/api/article_recommendation.py
@@ -182,7 +182,8 @@ def create_api_article_recommendation_router(
                 '''
                 The DOI to provide paper recommendations for.
                 '''
-            )
+            ),
+            example='10.1101/2022.08.08.502889'
         ),
         fields: str = fastapi.Query(
             default=','.join(sorted(DEFAULT_LIKE_S2_RECOMMENDATION_FIELDS)),

--- a/sciety_labs/app/routers/articles.py
+++ b/sciety_labs/app/routers/articles.py
@@ -32,7 +32,7 @@ def get_article_recommendation_filter_parameters(
 ) -> ArticleRecommendationFilterParameters:
     return ArticleRecommendationFilterParameters(
         exclude_article_dois={article_doi},
-        from_publication_date=date.today() - timedelta(days=60),
+        from_publication_date=date.today() - timedelta(days=120),
         evaluated_only=True
     )
 

--- a/sciety_labs/app/routers/articles.py
+++ b/sciety_labs/app/routers/articles.py
@@ -15,10 +15,11 @@ from sciety_labs.app.utils.common import (
     get_page_title
 )
 from sciety_labs.app.utils.recommendation import (
+    DEFAULT_PUBLISHED_WITHIN_LAST_N_DAYS_BY_EVALUATED_ONLY,
     get_article_recommendation_list_for_article_dois,
     get_article_recommendation_page_and_item_count_for_article_dois
 )
-from sciety_labs.models.article import iter_preprint_article_mention
+from sciety_labs.models.article import ArticleStats, iter_preprint_article_mention
 from sciety_labs.providers.article_recommendation import ArticleRecommendationFilterParameters
 from sciety_labs.utils.pagination import get_url_pagination_state_for_pagination_parameters
 from sciety_labs.utils.text import remove_markup_or_none
@@ -28,12 +29,17 @@ LOGGER = logging.getLogger(__name__)
 
 
 def get_article_recommendation_filter_parameters(
-    article_doi: str
+    article_doi: str,
+    article_stats: Optional[ArticleStats]
 ) -> ArticleRecommendationFilterParameters:
+    evaluated_only = bool(article_stats and article_stats.evaluation_count)
+    published_within_last_n_days = (
+        DEFAULT_PUBLISHED_WITHIN_LAST_N_DAYS_BY_EVALUATED_ONLY[evaluated_only]
+    )
     return ArticleRecommendationFilterParameters(
         exclude_article_dois={article_doi},
-        from_publication_date=date.today() - timedelta(days=365),
-        evaluated_only=True
+        from_publication_date=date.today() - timedelta(days=published_within_last_n_days),
+        evaluated_only=evaluated_only
     )
 
 
@@ -80,7 +86,10 @@ def create_articles_router(
             .google_sheet_article_image_provider.get_article_images_by_doi(article_doi)
         )
 
-        filter_parameters = get_article_recommendation_filter_parameters(article_doi)
+        filter_parameters = get_article_recommendation_filter_parameters(
+            article_doi,
+            article_stats=article_stats
+        )
         try:
             all_article_recommendations = list(
                 iter_preprint_article_mention(
@@ -136,7 +145,14 @@ def create_articles_router(
             app_providers_and_models
             .crossref_metadata_provider.get_article_metadata_by_doi(article_doi)
         )
-        filter_parameters = get_article_recommendation_filter_parameters(article_doi)
+        article_stats = (
+            app_providers_and_models
+            .evaluation_stats_model.get_article_stats_by_article_doi(article_doi)
+        )
+        filter_parameters = get_article_recommendation_filter_parameters(
+            article_doi,
+            article_stats=article_stats
+        )
         article_recommendation_with_article_meta, item_count = (
             get_article_recommendation_page_and_item_count_for_article_dois(
                 [article_doi],

--- a/sciety_labs/app/routers/articles.py
+++ b/sciety_labs/app/routers/articles.py
@@ -32,7 +32,7 @@ def get_article_recommendation_filter_parameters(
 ) -> ArticleRecommendationFilterParameters:
     return ArticleRecommendationFilterParameters(
         exclude_article_dois={article_doi},
-        from_publication_date=date.today() - timedelta(days=120),
+        from_publication_date=date.today() - timedelta(days=365),
         evaluated_only=True
     )
 

--- a/sciety_labs/app/utils/recommendation.py
+++ b/sciety_labs/app/utils/recommendation.py
@@ -3,7 +3,10 @@ from typing import Optional, Sequence, Tuple
 
 from sciety_labs.app.app_providers_and_models import AppProvidersAndModels
 from sciety_labs.models.article import ArticleMention, iter_preprint_article_mention
-from sciety_labs.providers.article_recommendation import ArticleRecommendationList
+from sciety_labs.providers.article_recommendation import (
+    ArticleRecommendationFilterParameters,
+    ArticleRecommendationList
+)
 from sciety_labs.utils.pagination import UrlPaginationParameters
 
 
@@ -13,6 +16,7 @@ LOGGER = logging.getLogger(__name__)
 def get_article_recommendation_list_for_article_dois(
     article_dois: Sequence[str],
     app_providers_and_models: AppProvidersAndModels,
+    filter_parameters: Optional[ArticleRecommendationFilterParameters] = None,
     max_recommendations: Optional[int] = None
 ) -> ArticleRecommendationList:
     if len(article_dois) == 1 and app_providers_and_models.single_article_recommendation_provider:
@@ -21,7 +25,8 @@ def get_article_recommendation_list_for_article_dois(
             app_providers_and_models
             .single_article_recommendation_provider.get_article_recommendation_list_for_article_doi(
                 article_doi=article_dois[0],
-                max_recommendations=max_recommendations
+                max_recommendations=max_recommendations,
+                filter_parameters=filter_parameters
             )
         )
     else:
@@ -40,12 +45,14 @@ def get_article_recommendation_page_and_item_count_for_article_dois(
     article_dois: Sequence[str],
     app_providers_and_models: AppProvidersAndModels,
     max_recommendations: Optional[int],
-    pagination_parameters: UrlPaginationParameters
+    pagination_parameters: UrlPaginationParameters,
+    filter_parameters: Optional[ArticleRecommendationFilterParameters] = None
 ) -> Tuple[Sequence[ArticleMention], int]:
     article_recommendation_list = get_article_recommendation_list_for_article_dois(
         article_dois,
         app_providers_and_models=app_providers_and_models,
-        max_recommendations=max_recommendations
+        max_recommendations=max_recommendations,
+        filter_parameters=filter_parameters
     )
     all_article_recommendations = list(
         iter_preprint_article_mention(article_recommendation_list.recommendations)

--- a/sciety_labs/app/utils/recommendation.py
+++ b/sciety_labs/app/utils/recommendation.py
@@ -13,6 +13,12 @@ from sciety_labs.utils.pagination import UrlPaginationParameters
 LOGGER = logging.getLogger(__name__)
 
 
+DEFAULT_PUBLISHED_WITHIN_LAST_N_DAYS_BY_EVALUATED_ONLY = {
+    False: 60,
+    True: 365
+}
+
+
 def get_article_recommendation_list_for_article_dois(
     article_dois: Sequence[str],
     app_providers_and_models: AppProvidersAndModels,

--- a/sciety_labs/providers/article_recommendation.py
+++ b/sciety_labs/providers/article_recommendation.py
@@ -7,7 +7,7 @@ from sciety_labs.models.article import ArticleMention
 
 @dataclasses.dataclass(frozen=True)
 class ArticleRecommendation(ArticleMention):
-    pass
+    score: Optional[float] = None
 
 
 @dataclasses.dataclass(frozen=True)

--- a/sciety_labs/providers/article_recommendation.py
+++ b/sciety_labs/providers/article_recommendation.py
@@ -1,6 +1,6 @@
 import dataclasses
-from datetime import datetime
-from typing import Iterable, Optional, Protocol, Sequence
+from datetime import date, datetime
+from typing import Iterable, Optional, Protocol, Sequence, Set
 
 from sciety_labs.models.article import ArticleMention
 
@@ -8,6 +8,13 @@ from sciety_labs.models.article import ArticleMention
 @dataclasses.dataclass(frozen=True)
 class ArticleRecommendation(ArticleMention):
     pass
+
+
+@dataclasses.dataclass(frozen=True)
+class ArticleRecommendationFilterParameters:
+    from_publication_date: Optional[date] = None
+    evaluated_only: bool = False
+    exclude_article_dois: Optional[Set[str]] = None
 
 
 @dataclasses.dataclass(frozen=True)

--- a/sciety_labs/providers/article_recommendation.py
+++ b/sciety_labs/providers/article_recommendation.py
@@ -36,6 +36,7 @@ class SingleArticleRecommendationProvider(Protocol):
     def get_article_recommendation_list_for_article_doi(
         self,
         article_doi: str,
-        max_recommendations: Optional[int] = None
+        max_recommendations: Optional[int] = None,
+        filter_parameters: Optional[ArticleRecommendationFilterParameters] = None
     ) -> ArticleRecommendationList:
         pass

--- a/sciety_labs/providers/opensearch_article_recommendation.py
+++ b/sciety_labs/providers/opensearch_article_recommendation.py
@@ -221,8 +221,7 @@ class OpenSearchArticleRecommendation(SingleArticleRecommendationProvider):
         if filter_parameters is None:
             filter_parameters = ArticleRecommendationFilterParameters(
                 exclude_article_dois={article_doi},
-                from_publication_date=date.today() - timedelta(days=60),
-                evaluated_only=True
+                from_publication_date=date.today() - timedelta(days=60)
             )
         LOGGER.info('filter_parameters: %r', filter_parameters)
         hits = self._run_vector_search_and_get_hits(

--- a/sciety_labs/providers/opensearch_article_recommendation.py
+++ b/sciety_labs/providers/opensearch_article_recommendation.py
@@ -83,7 +83,7 @@ def get_vector_search_query(  # pylint: disable=too-many-arguments
     max_results: int,
     exclude_article_dois: Optional[Set[str]] = None,
     from_publication_date: Optional[date] = None,
-    evaluated_only: bool = False
+    evaluated_only: bool = True
 ) -> dict:
     vector_query_part: dict = {
         'vector': query_vector,

--- a/sciety_labs/providers/opensearch_article_recommendation.py
+++ b/sciety_labs/providers/opensearch_article_recommendation.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from datetime import date, timedelta
-from typing import Iterable, Optional, Sequence, Set, TypedDict
+from typing import Iterable, Optional, Sequence, TypedDict
 
 import numpy.typing as npt
 
@@ -11,6 +11,7 @@ from sciety_labs.models.article import ArticleMetaData
 
 from sciety_labs.providers.article_recommendation import (
     ArticleRecommendation,
+    ArticleRecommendationFilterParameters,
     ArticleRecommendationList,
     SingleArticleRecommendationProvider
 )
@@ -81,26 +82,24 @@ def get_vector_search_query(  # pylint: disable=too-many-arguments
     query_vector: npt.ArrayLike,
     embedding_vector_mapping_name: str,
     max_results: int,
-    exclude_article_dois: Optional[Set[str]] = None,
-    from_publication_date: Optional[date] = None,
-    evaluated_only: bool = True
+    filter_parameters: ArticleRecommendationFilterParameters
 ) -> dict:
     vector_query_part: dict = {
         'vector': query_vector,
         'k': max_results
     }
     bool_filter: dict = {}
-    if exclude_article_dois:
+    if filter_parameters.exclude_article_dois:
         bool_filter.setdefault('must_not', []).append({
-            'ids': {'values': sorted(exclude_article_dois)}
+            'ids': {'values': sorted(filter_parameters.exclude_article_dois)}
         })
-    if from_publication_date:
+    if filter_parameters.from_publication_date:
         bool_filter.setdefault('must', []).append({
             'range': {
-                'publication_date': {'gte': from_publication_date.isoformat()}
+                'publication_date': {'gte': filter_parameters.from_publication_date.isoformat()}
             }
         })
-    if evaluated_only:
+    if filter_parameters.evaluated_only:
         bool_filter.setdefault('must', []).append({
             'range': {'evaluation_count': {'gte': 1}}
         })
@@ -146,15 +145,13 @@ class OpenSearchArticleRecommendation(SingleArticleRecommendationProvider):
         embedding_vector_mapping_name: str,
         source_includes: Sequence[str],
         max_results: int,
-        exclude_article_dois: Optional[Set[str]] = None,
-        from_publication_date: Optional[date] = None
+        filter_parameters: ArticleRecommendationFilterParameters
     ) -> Sequence[dict]:
         search_query = get_vector_search_query(
             query_vector=query_vector,
             embedding_vector_mapping_name=embedding_vector_mapping_name,
             max_results=max_results,
-            exclude_article_dois=exclude_article_dois,
-            from_publication_date=from_publication_date
+            filter_parameters=filter_parameters
         )
         LOGGER.info('search_query JSON: %s', json.dumps(search_query))
         client_search_results = (
@@ -220,16 +217,19 @@ class OpenSearchArticleRecommendation(SingleArticleRecommendationProvider):
         if embedding_vector is None:
             return ArticleRecommendationList([], get_utcnow())
         LOGGER.info('Found embedding vector: %d', len(embedding_vector))
-        from_publication_date = date.today() - timedelta(days=60)
-        LOGGER.info('from_publication_date: %r', from_publication_date)
+        filter_parameters = ArticleRecommendationFilterParameters(
+            exclude_article_dois={article_doi},
+            from_publication_date=date.today() - timedelta(days=60),
+            evaluated_only=True
+        )
+        LOGGER.info('filter_parameters: %r', filter_parameters)
         hits = self._run_vector_search_and_get_hits(
             embedding_vector,
             index=self.index_name,
             embedding_vector_mapping_name=self.embedding_vector_mapping_name,
             source_includes=['doi', 'title', 'authors', 'publication_date'],
             max_results=max_recommendations,
-            exclude_article_dois={article_doi},
-            from_publication_date=from_publication_date
+            filter_parameters=filter_parameters
         )
         LOGGER.debug('hits: %r', hits)
         recommendations = list(iter_article_recommendation_from_opensearch_hits(

--- a/sciety_labs/providers/opensearch_article_recommendation.py
+++ b/sciety_labs/providers/opensearch_article_recommendation.py
@@ -202,7 +202,8 @@ class OpenSearchArticleRecommendation(SingleArticleRecommendationProvider):
     def get_article_recommendation_list_for_article_doi(
         self,
         article_doi: str,
-        max_recommendations: Optional[int] = None
+        max_recommendations: Optional[int] = None,
+        filter_parameters: Optional[ArticleRecommendationFilterParameters] = None
     ) -> ArticleRecommendationList:
         if not max_recommendations:
             max_recommendations = DEFAULT_OPENSEARCH_MAX_RECOMMENDATIONS
@@ -217,11 +218,12 @@ class OpenSearchArticleRecommendation(SingleArticleRecommendationProvider):
         if embedding_vector is None:
             return ArticleRecommendationList([], get_utcnow())
         LOGGER.info('Found embedding vector: %d', len(embedding_vector))
-        filter_parameters = ArticleRecommendationFilterParameters(
-            exclude_article_dois={article_doi},
-            from_publication_date=date.today() - timedelta(days=60),
-            evaluated_only=True
-        )
+        if filter_parameters is None:
+            filter_parameters = ArticleRecommendationFilterParameters(
+                exclude_article_dois={article_doi},
+                from_publication_date=date.today() - timedelta(days=60),
+                evaluated_only=True
+            )
         LOGGER.info('filter_parameters: %r', filter_parameters)
         hits = self._run_vector_search_and_get_hits(
             embedding_vector,

--- a/sciety_labs/providers/opensearch_article_recommendation.py
+++ b/sciety_labs/providers/opensearch_article_recommendation.py
@@ -77,12 +77,13 @@ def iter_article_recommendation_from_opensearch_hits(
         )
 
 
-def get_vector_search_query(
+def get_vector_search_query(  # pylint: disable=too-many-arguments
     query_vector: npt.ArrayLike,
     embedding_vector_mapping_name: str,
     max_results: int,
     exclude_article_dois: Optional[Set[str]] = None,
-    from_publication_date: Optional[date] = None
+    from_publication_date: Optional[date] = None,
+    evaluated_only: bool = False
 ) -> dict:
     vector_query_part: dict = {
         'vector': query_vector,
@@ -98,6 +99,10 @@ def get_vector_search_query(
             'range': {
                 'publication_date': {'gte': from_publication_date.isoformat()}
             }
+        })
+    if evaluated_only:
+        bool_filter.setdefault('must', []).append({
+            'range': {'evaluation_count': {'gte': 1}}
         })
     if bool_filter:
         vector_query_part = {

--- a/sciety_labs/utils/distance.py
+++ b/sciety_labs/utils/distance.py
@@ -1,0 +1,10 @@
+import numpy as np
+import numpy.typing as npt
+
+
+def cosine_similarity(
+    vector_a: npt.ArrayLike,
+    vector_b: npt.ArrayLike
+):
+    # like scipy.spatial.distance.cosine
+    return np.dot(vector_a, vector_b) / (np.linalg.norm(vector_a) * np.linalg.norm(vector_b))

--- a/tests/unit_tests/app/routers/api/article_recommendation_test.py
+++ b/tests/unit_tests/app/routers/api/article_recommendation_test.py
@@ -1,6 +1,6 @@
 from datetime import date
 from typing import Iterable
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 import pytest
 
 from fastapi import FastAPI
@@ -14,7 +14,7 @@ from sciety_labs.app.routers.api.article_recommendation import (
     get_s2_recommended_paper_response_for_article_recommendation,
     get_s2_recommended_papers_response_for_article_recommendation_list
 )
-from sciety_labs.models.article import ArticleMetaData
+from sciety_labs.models.article import ArticleMetaData, ArticleStats
 from sciety_labs.providers.article_recommendation import (
     ArticleRecommendation,
     ArticleRecommendationList
@@ -79,6 +79,9 @@ class TestGetS2RecommendedPaperResponseForArticleRecommendation:
                     article_title='Title 1',
                     author_name_list=['Author 1', 'Author 2'],
                     published_date=date(2001, 2, 3)
+                ),
+                article_stats=ArticleStats(
+                    evaluation_count=123
                 )
             )
         )
@@ -89,7 +92,8 @@ class TestGetS2RecommendedPaperResponseForArticleRecommendation:
             'authors': [
                 {'name': 'Author 1'},
                 {'name': 'Author 2'}
-            ]
+            ],
+            '_evaluationCount': 123
         }
 
     def test_should_be_able_to_select_fields(self):
@@ -160,6 +164,7 @@ class TestArticleRecommendationApi:
         get_article_recommendation_list_for_article_dois_mock.assert_called_with(
             [DOI_1],
             app_providers_and_models=app_providers_and_models_mock,
+            filter_parameters=ANY,
             max_recommendations=None
         )
 

--- a/tests/unit_tests/app/routers/api/article_recommendation_test.py
+++ b/tests/unit_tests/app/routers/api/article_recommendation_test.py
@@ -67,7 +67,8 @@ class TestGetS2RecommendedPaperResponseForArticleRecommendation:
             )
         )
         assert result == {
-            'externalIds': {'DOI': DOI_1}
+            'externalIds': {'DOI': DOI_1},
+            '_score': None
         }
 
     def test_should_return_response_for_paper_with_metadata(self):
@@ -82,7 +83,8 @@ class TestGetS2RecommendedPaperResponseForArticleRecommendation:
                 ),
                 article_stats=ArticleStats(
                     evaluation_count=123
-                )
+                ),
+                score=0.9
             )
         )
         assert result == {
@@ -93,7 +95,8 @@ class TestGetS2RecommendedPaperResponseForArticleRecommendation:
                 {'name': 'Author 1'},
                 {'name': 'Author 2'}
             ],
-            '_evaluationCount': 123
+            '_evaluationCount': 123,
+            '_score': 0.9
         }
 
     def test_should_be_able_to_select_fields(self):

--- a/tests/unit_tests/providers/opensearch_article_recommendation_test.py
+++ b/tests/unit_tests/providers/opensearch_article_recommendation_test.py
@@ -3,6 +3,7 @@ from datetime import date
 from sciety_labs.providers.article_recommendation import ArticleRecommendationFilterParameters
 from sciety_labs.providers.opensearch_article_recommendation import (
     get_article_meta_from_document,
+    get_article_recommendation_from_document,
     get_vector_search_query,
     iter_article_recommendation_from_opensearch_hits
 )
@@ -43,6 +44,22 @@ class TestGetArticleMetaFromDocument:
             'publication_date': '2001-02-03'
         })
         assert article_meta.published_date == date(2001, 2, 3)
+
+
+class TestGetArticleRecommendationFromDocument:
+    def test_should_not_include_stats_without_evaluation_count(self):
+        recommendation = get_article_recommendation_from_document({
+            **MINIMAL_DOCUMENT_DICT_1
+        })
+        assert recommendation.article_stats is None
+
+    def test_should_include_evaluation_count_as_stats(self):
+        recommendation = get_article_recommendation_from_document({
+            **MINIMAL_DOCUMENT_DICT_1,
+            'evaluation_count': 123
+        })
+        assert recommendation.article_stats
+        assert recommendation.article_stats.evaluation_count == 123
 
 
 class TestIterArticleRecommendationFromOpenSearchHits:

--- a/tests/unit_tests/providers/opensearch_article_recommendation_test.py
+++ b/tests/unit_tests/providers/opensearch_article_recommendation_test.py
@@ -120,9 +120,62 @@ class TestGetVectorSearchQuery:
                         'filter': {
                             'bool': {
                                 'must': [{
-                                    'range': {
-                                        'publication_date': {'gte': '2001-02-03'}
-                                    }
+                                    'range': {'publication_date': {'gte': '2001-02-03'}}
+                                }]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+    def test_should_add_evaluated_only_filter(self):
+        search_query = get_vector_search_query(
+            query_vector=VECTOR_1,
+            embedding_vector_mapping_name='embedding1',
+            max_results=3,
+            evaluated_only=True
+        )
+        assert search_query == {
+            'size': 3,
+            'query': {
+                'knn': {
+                    'embedding1': {
+                        'vector': VECTOR_1,
+                        'k': 3,
+                        'filter': {
+                            'bool': {
+                                'must': [{
+                                    'range': {'evaluation_count': {'gte': 1}}
+                                }]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+    def test_should_add_from_publication_date_and_evaluated_only_filter(self):
+        search_query = get_vector_search_query(
+            query_vector=VECTOR_1,
+            embedding_vector_mapping_name='embedding1',
+            max_results=3,
+            from_publication_date=date.fromisoformat('2001-02-03'),
+            evaluated_only=True
+        )
+        assert search_query == {
+            'size': 3,
+            'query': {
+                'knn': {
+                    'embedding1': {
+                        'vector': VECTOR_1,
+                        'k': 3,
+                        'filter': {
+                            'bool': {
+                                'must': [{
+                                    'range': {'publication_date': {'gte': '2001-02-03'}}
+                                }, {
+                                    'range': {'evaluation_count': {'gte': 1}}
                                 }]
                             }
                         }

--- a/tests/unit_tests/providers/opensearch_article_recommendation_test.py
+++ b/tests/unit_tests/providers/opensearch_article_recommendation_test.py
@@ -62,7 +62,8 @@ class TestGetVectorSearchQuery:
         search_query = get_vector_search_query(
             query_vector=VECTOR_1,
             embedding_vector_mapping_name='embedding1',
-            max_results=3
+            max_results=3,
+            evaluated_only=False
         )
         assert search_query == {
             'size': 3,
@@ -81,7 +82,8 @@ class TestGetVectorSearchQuery:
             query_vector=VECTOR_1,
             embedding_vector_mapping_name='embedding1',
             max_results=3,
-            exclude_article_dois={DOI_1}
+            exclude_article_dois={DOI_1},
+            evaluated_only=False
         )
         LOGGER.debug('search_query: %r', search_query)
         assert search_query == {
@@ -108,7 +110,8 @@ class TestGetVectorSearchQuery:
             query_vector=VECTOR_1,
             embedding_vector_mapping_name='embedding1',
             max_results=3,
-            from_publication_date=date.fromisoformat('2001-02-03')
+            from_publication_date=date.fromisoformat('2001-02-03'),
+            evaluated_only=False
         )
         assert search_query == {
             'size': 3,

--- a/tests/unit_tests/providers/opensearch_article_recommendation_test.py
+++ b/tests/unit_tests/providers/opensearch_article_recommendation_test.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import date
+from sciety_labs.providers.article_recommendation import ArticleRecommendationFilterParameters
 from sciety_labs.providers.opensearch_article_recommendation import (
     get_article_meta_from_document,
     get_vector_search_query,
@@ -63,7 +64,9 @@ class TestGetVectorSearchQuery:
             query_vector=VECTOR_1,
             embedding_vector_mapping_name='embedding1',
             max_results=3,
-            evaluated_only=False
+            filter_parameters=ArticleRecommendationFilterParameters(
+                evaluated_only=False
+            )
         )
         assert search_query == {
             'size': 3,
@@ -82,8 +85,10 @@ class TestGetVectorSearchQuery:
             query_vector=VECTOR_1,
             embedding_vector_mapping_name='embedding1',
             max_results=3,
-            exclude_article_dois={DOI_1},
-            evaluated_only=False
+            filter_parameters=ArticleRecommendationFilterParameters(
+                exclude_article_dois={DOI_1},
+                evaluated_only=False
+            )
         )
         LOGGER.debug('search_query: %r', search_query)
         assert search_query == {
@@ -110,8 +115,10 @@ class TestGetVectorSearchQuery:
             query_vector=VECTOR_1,
             embedding_vector_mapping_name='embedding1',
             max_results=3,
-            from_publication_date=date.fromisoformat('2001-02-03'),
-            evaluated_only=False
+            filter_parameters=ArticleRecommendationFilterParameters(
+                from_publication_date=date.fromisoformat('2001-02-03'),
+                evaluated_only=False
+            )
         )
         assert search_query == {
             'size': 3,
@@ -137,7 +144,9 @@ class TestGetVectorSearchQuery:
             query_vector=VECTOR_1,
             embedding_vector_mapping_name='embedding1',
             max_results=3,
-            evaluated_only=True
+            filter_parameters=ArticleRecommendationFilterParameters(
+                evaluated_only=True
+            )
         )
         assert search_query == {
             'size': 3,
@@ -163,8 +172,10 @@ class TestGetVectorSearchQuery:
             query_vector=VECTOR_1,
             embedding_vector_mapping_name='embedding1',
             max_results=3,
-            from_publication_date=date.fromisoformat('2001-02-03'),
-            evaluated_only=True
+            filter_parameters=ArticleRecommendationFilterParameters(
+                from_publication_date=date.fromisoformat('2001-02-03'),
+                evaluated_only=True
+            )
         )
         assert search_query == {
             'size': 3,


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/791

The API has been updated to include an evaluated only filter, as well as the ability to increase the date range.

![image](https://github.com/sciety/sciety-labs/assets/1016473/382ca33f-494e-44c6-a1f4-621e8d07ce66)

The default date range will be `365` instead of `60`, when `evaluated_only` is set to true.

On website, the related article functionality for a single article will filter by evaluated only, if that article has evaluations.
e.g. `10.1101/2023.08.25.554769` has evaluations, therefore related articles will only show evaluated articles.

![image](https://github.com/sciety/sciety-labs/assets/1016473/44bb090a-254d-4aeb-8646-4a70e2cee2da)

`10.1101/2023.08.25.554769` doesn't have evaluations, which is reflected in the related articles:

![image](https://github.com/sciety/sciety-labs/assets/1016473/3d8cfcd4-7078-419a-98d5-6f065d419982)