### PR TITLE
Add data-user-agent to `head` to help identify bots

### DIFF
--- a/templates/macros/page.html
+++ b/templates/macros/page.html
@@ -7,7 +7,9 @@
 <!doctype html>
 <html lang="en" prefix="og: http://ogp.me/ns#">
 
-<head>
+<head
+    data-user-agent="{{ request.headers.get('User-Agent') }}"
+>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/469

The previous Cookiebot filtering didn't work.
This will test the assumption whether the server sees Cookiebot in the user agent (whilst JavaScript isn't).