### PR TITLE
OpenSearch: Use `preprints_v2` index

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ When configured, it will use OpenSearch instead of BigQuery to look up Semantic 
 | OPENSEARCH_USERNAME_FILE_PATH | File path to file containing the username |
 | OPENSEARCH_PASSWORD_FILE_PATH | File path to file containing the password |
 | OPENSEARCH_INDEX_V2_NAME | The index to use |
-| OPENSEARCH_EMBEDDING_VECTOR_MAPPING_NAME | Optional. When specified, it will use the OpenSearch embedding vector mapping to provide article recommendations for a single article (not yet used for lists). Otherwise it will continue to use Semantic Scholar. |
+| OPENSEARCH_INDEX_V2_EMBEDDING_VECTOR_MAPPING_NAME | Optional. When specified, it will use the OpenSearch embedding vector mapping to provide article recommendations for a single article (not yet used for lists). Otherwise it will continue to use Semantic Scholar. |
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ When configured, it will use OpenSearch instead of BigQuery to look up Semantic 
 | OPENSEARCH_PORT | Port to OpenSearch, e.g. 9200 |
 | OPENSEARCH_USERNAME_FILE_PATH | File path to file containing the username |
 | OPENSEARCH_PASSWORD_FILE_PATH | File path to file containing the password |
-| OPENSEARCH_INDEX_NAME | The index to use |
+| OPENSEARCH_INDEX_V2_NAME | The index to use |
 | OPENSEARCH_EMBEDDING_VECTOR_MAPPING_NAME | Optional. When specified, it will use the OpenSearch embedding vector mapping to provide article recommendations for a single article (not yet used for lists). Otherwise it will continue to use Semantic Scholar. |
 
 ## Configuration

--- a/sciety_labs/providers/opensearch.py
+++ b/sciety_labs/providers/opensearch.py
@@ -17,7 +17,9 @@ class OpenSearchEnvVariables:
     OPENSEARCH_USERNAME_FILE_PATH = 'OPENSEARCH_USERNAME_FILE_PATH'
     OPENSEARCH_PASSWORD_FILE_PATH = 'OPENSEARCH_PASSWORD_FILE_PATH'
     OPENSEARCH_INDEX_V2_NAME = 'OPENSEARCH_INDEX_V2_NAME'
-    OPENSEARCH_EMBEDDING_VECTOR_MAPPING_NAME = 'OPENSEARCH_EMBEDDING_VECTOR_MAPPING_NAME'
+    OPENSEARCH_INDEX_V2_EMBEDDING_VECTOR_MAPPING_NAME = (
+        'OPENSEARCH_INDEX_V2_EMBEDDING_VECTOR_MAPPING_NAME'
+    )
 
 
 def get_optional_secret_file_path_from_env_var_file_path(env_var_name: str) -> Optional[str]:
@@ -73,7 +75,7 @@ class OpenSearchConnectionConfig:  # pylint: disable=too-many-instance-attribute
             LOGGER.info('no OpenSearch username or password configured')
             return None
         embedding_vector_mapping_name = os.getenv(
-            OpenSearchEnvVariables.OPENSEARCH_EMBEDDING_VECTOR_MAPPING_NAME
+            OpenSearchEnvVariables.OPENSEARCH_INDEX_V2_EMBEDDING_VECTOR_MAPPING_NAME
         )
         return OpenSearchConnectionConfig(
             hostname=hostname,

--- a/sciety_labs/providers/opensearch.py
+++ b/sciety_labs/providers/opensearch.py
@@ -16,7 +16,7 @@ class OpenSearchEnvVariables:
     OPENSEARCH_PORT = 'OPENSEARCH_PORT'
     OPENSEARCH_USERNAME_FILE_PATH = 'OPENSEARCH_USERNAME_FILE_PATH'
     OPENSEARCH_PASSWORD_FILE_PATH = 'OPENSEARCH_PASSWORD_FILE_PATH'
-    OPENSEARCH_INDEX_NAME = 'OPENSEARCH_INDEX_NAME'
+    OPENSEARCH_INDEX_V2_NAME = 'OPENSEARCH_INDEX_V2_NAME'
     OPENSEARCH_EMBEDDING_VECTOR_MAPPING_NAME = 'OPENSEARCH_EMBEDDING_VECTOR_MAPPING_NAME'
 
 
@@ -59,7 +59,7 @@ class OpenSearchConnectionConfig:  # pylint: disable=too-many-instance-attribute
         if not hostname or not port_str:
             LOGGER.info('no OpenSearch hostname or port configured')
             return None
-        index_name = os.getenv(OpenSearchEnvVariables.OPENSEARCH_INDEX_NAME)
+        index_name = os.getenv(OpenSearchEnvVariables.OPENSEARCH_INDEX_V2_NAME)
         if not index_name:
             LOGGER.info('no OpenSearch index name configured')
             return None

--- a/tests/unit_tests/providers/opensearch_test.py
+++ b/tests/unit_tests/providers/opensearch_test.py
@@ -25,7 +25,7 @@ class TestOpenSearchConnectionConfig:
         env_mock[OpenSearchEnvVariables.OPENSEARCH_PORT] = '1234'
         env_mock[OpenSearchEnvVariables.OPENSEARCH_USERNAME_FILE_PATH] = str(username_file_path)
         env_mock[OpenSearchEnvVariables.OPENSEARCH_PASSWORD_FILE_PATH] = str(password_file_path)
-        env_mock[OpenSearchEnvVariables.OPENSEARCH_INDEX_NAME] = 'index1'
+        env_mock[OpenSearchEnvVariables.OPENSEARCH_INDEX_V2_NAME] = 'index1'
         env_mock[OpenSearchEnvVariables.OPENSEARCH_EMBEDDING_VECTOR_MAPPING_NAME] = 'vector1'
         config = OpenSearchConnectionConfig.from_env()
         assert config == OpenSearchConnectionConfig(

--- a/tests/unit_tests/providers/opensearch_test.py
+++ b/tests/unit_tests/providers/opensearch_test.py
@@ -26,7 +26,9 @@ class TestOpenSearchConnectionConfig:
         env_mock[OpenSearchEnvVariables.OPENSEARCH_USERNAME_FILE_PATH] = str(username_file_path)
         env_mock[OpenSearchEnvVariables.OPENSEARCH_PASSWORD_FILE_PATH] = str(password_file_path)
         env_mock[OpenSearchEnvVariables.OPENSEARCH_INDEX_V2_NAME] = 'index1'
-        env_mock[OpenSearchEnvVariables.OPENSEARCH_EMBEDDING_VECTOR_MAPPING_NAME] = 'vector1'
+        env_mock[OpenSearchEnvVariables.OPENSEARCH_INDEX_V2_EMBEDDING_VECTOR_MAPPING_NAME] = (
+            'vector1'
+        )
         config = OpenSearchConnectionConfig.from_env()
         assert config == OpenSearchConnectionConfig(
             hostname='hostname1',


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/794

The structure of `preprints_v2` is different and therefore incompatible.
Renamed environment variables so that they can be configured ahead of time.