### PR TITLE
Lazy load related articles using htmx

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -262,3 +262,14 @@ section.article-stats {
 .search-form__submit {
     display: inline-block;
 }
+
+/* htmx-request */
+.htmx-request {
+  position: absolute;
+  visibility: hidden;
+}
+
+.htmx-request:after {
+  content: 'Loading...';
+  visibility: visible;
+}

--- a/templates/fragments/article-recommendations.html
+++ b/templates/fragments/article-recommendations.html
@@ -1,0 +1,3 @@
+{%- from 'macros/article.html' import render_article_list_content with context %}
+
+{{ render_article_list_content(article_list_content) }}

--- a/templates/pages/article-by-article-doi.html
+++ b/templates/pages/article-by-article-doi.html
@@ -53,20 +53,18 @@
             </section>
             {%- endif %}
 
-            {%- if article_recommendation_list %}
-            <section id="article-recommendations">
-                <h2><a href="{{ article_recommendation_url }}">Related articles</a></h2>
-                {{ render_article_list_content(article_recommendation_list) }}
-                <a href="{{ article_recommendation_url }}">More</a>
-            </section>
-            {%- else %}
             <section id="article-recommendations">
                 <h2>Related articles</h2>
-                <p>Related articles are currently not available for this article.</p>  
+                <p
+                    hx-get="{{ article_recommendation_fragment_url }}"
+                    hx-trigger="load"
+                >
+                    Related articles are currently not available for this article.
+                </p>
             </section>
-            {%- endif %}
-
         </div>
 
     </main>
+
+    <script src="https://unpkg.com/htmx.org@1.9.9"></script>
 {%- endcall %}


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/821

This also removed the link to the page with more related articles, for a particular article, for now.