### PR TITLE
Update request scope with original scheme

### DIFF
--- a/sciety_labs/app/main.py
+++ b/sciety_labs/app/main.py
@@ -8,6 +8,7 @@ from fastapi.staticfiles import StaticFiles
 import markupsafe
 
 import bleach
+
 from sciety_labs.app.app_providers_and_models import AppProvidersAndModels
 from sciety_labs.app.app_update_manager import AppUpdateManager
 from sciety_labs.app.routers.api.app import create_api_app
@@ -26,7 +27,10 @@ from sciety_labs.utils.datetime import (
     get_date_as_isoformat,
     get_timestamp_as_isoformat
 )
-from sciety_labs.utils.fastapi import get_likely_client_ip_for_request
+from sciety_labs.utils.fastapi import (
+    get_likely_client_ip_for_request,
+    update_request_scope_to_original_url_middleware
+)
 
 
 LOGGER = logging.getLogger(__name__)
@@ -101,6 +105,8 @@ def create_app():  # pylint: disable=too-many-locals, too-many-statements
         templates=templates,
         search_feeds_config=search_feeds_config
     ))
+
+    app.middleware('http')(update_request_scope_to_original_url_middleware)
 
     @app.exception_handler(404)
     async def not_found_exception_handler(request: Request, exception: HTTPException):

--- a/sciety_labs/app/routers/articles.py
+++ b/sciety_labs/app/routers/articles.py
@@ -82,8 +82,11 @@ def create_articles_router(
         )
 
         article_recommendation_url = (
-            request.url.replace(path='/articles/article-recommendations/by')
+            request.url.replace(
+                path='/articles/article-recommendations/by'
+            )
         )
+        LOGGER.info('article_recommendation_url: %r', article_recommendation_url)
         article_recommendation_fragment_url = (
             article_recommendation_url.include_query_params(
                 fragment=True,

--- a/sciety_labs/utils/fastapi.py
+++ b/sciety_labs/utils/fastapi.py
@@ -26,3 +26,17 @@ def get_likely_client_ip_for_request(request: Request) -> Optional[str]:
     if request.client:
         return request.client.host
     return None
+
+
+def update_request_scope_to_original_url(request: Request):
+    original_scheme = request.headers.get('x-scheme')
+    if original_scheme:
+        request.scope['scheme'] = original_scheme
+
+
+async def update_request_scope_to_original_url_middleware(
+    request: Request,
+    call_next
+):
+    update_request_scope_to_original_url(request)
+    return await call_next(request)


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/821

This is necessary, as otherwise request.url uses "http" instead of "https".