### PR TITLE
Remove page parameter for first page

### DIFF
--- a/sciety_labs/utils/pagination.py
+++ b/sciety_labs/utils/pagination.py
@@ -67,9 +67,12 @@ def get_url_pagination_state_for_url(  # pylint: disable=too-many-arguments
     if item_count is None and remaining_item_iterable is None:
         raise AssertionError('either item_count or remaining_item_iterable must be specified')
     if page > 1:
-        previous_page_url = str(url.include_query_params(
-            page=page - 1
-        ))
+        if page == 2:
+            previous_page_url = str(url.remove_query_params(['page']))
+        else:
+            previous_page_url = str(url.include_query_params(
+                page=page - 1
+            ))
     has_next_page = False
     if item_count is not None:
         page_count = get_page_count_for_item_count_and_items_per_page(

--- a/tests/unit_tests/utils/pagination_test.py
+++ b/tests/unit_tests/utils/pagination_test.py
@@ -102,19 +102,19 @@ class TestGetUrlPaginationStateForUrl:
     def test_should_calculate_previous_and_next_page_url(self):
         url_pagination_state = get_url_pagination_state_for_url(
             url=URL_WITHOUT_PAGE_PARAMETER,
-            page=2,
+            page=3,
             items_per_page=10,
-            item_count=30
+            item_count=40
         )
         assert url_pagination_state.previous_page_url is not None
         assert url_pagination_state.next_page_url is not None
         assert (
             _parse_query_parameters_from_url(url_pagination_state.previous_page_url).get('page')
-            == '1'
+            == '2'
         )
         assert (
             _parse_query_parameters_from_url(url_pagination_state.next_page_url).get('page')
-            == '3'
+            == '4'
         )
 
     def test_should_calculate_previous_but_not_next_page_url_on_last_page(self):
@@ -134,7 +134,7 @@ class TestGetUrlPaginationStateForUrl:
     def test_should_calculate_previous_and_next_page_url_with_remaining_item_iterable(self):
         url_pagination_state = get_url_pagination_state_for_url(
             url=URL_WITHOUT_PAGE_PARAMETER,
-            page=2,
+            page=3,
             items_per_page=10,
             item_count=None,
             remaining_item_iterable=iter(['something'])
@@ -143,13 +143,26 @@ class TestGetUrlPaginationStateForUrl:
         assert url_pagination_state.next_page_url is not None
         assert (
             _parse_query_parameters_from_url(url_pagination_state.previous_page_url).get('page')
-            == '1'
+            == '2'
         )
         assert (
             _parse_query_parameters_from_url(url_pagination_state.next_page_url).get('page')
-            == '3'
+            == '4'
         )
         assert url_pagination_state.page_count is None
+
+    def test_should_remove_page_parameter_for_first_page(self):
+        url_pagination_state = get_url_pagination_state_for_url(
+            url=URL_WITHOUT_PAGE_PARAMETER,
+            page=2,
+            items_per_page=10,
+            item_count=30
+        )
+        assert url_pagination_state.previous_page_url is not None
+        assert (
+            _parse_query_parameters_from_url(url_pagination_state.previous_page_url).get('page')
+            is None
+        )
 
     def test_should_calculate_page_count_on_last_page_of_iterable(self):
         url_pagination_state = get_url_pagination_state_for_url(


### PR DESCRIPTION
related to https://github.com/elifesciences/data-hub-issues/issues/821

Remove the page parameter on the first page so that it matches the url when first getting to the related article page. (Avoiding multiple URLs for the same content)