### PR TITLE
Lazy load list recommendations

### DIFF
--- a/templates/pages/article-recommendations-by-sciety-list-id.html
+++ b/templates/pages/article-recommendations-by-sciety-list-id.html
@@ -1,6 +1,5 @@
 {%- from 'macros/page.html' import render_page with context %}
 {%- from 'macros/article.html' import render_article_list_content with context %}
-{%- from 'macros/pagination.html' import render_pagination_header, render_pagination %}
 
 {%- call render_page() %}
     <main class="page-content" id="mainContent">
@@ -37,17 +36,19 @@
                         </ul>
                     </div>
                     {%- endif %}
-
-                    <section>
-                        {{ render_pagination_header(pagination, list_type_name='article recommendations') }}
-                    </section>
                 </div>
             </header>
 
             <section>
-                {{ render_article_list_content(article_list_content) }}
-                {{ render_pagination(pagination) }}
+                <p
+                    hx-get="{{ article_recommendation_fragment_url }}"
+                    hx-trigger="load"
+                >
+                    Related articles are currently not available for this list.
+                </p>
             </section>
         </div>
     </main>
+
+    <script src="https://unpkg.com/htmx.org@1.9.9"></script>
 {%- endcall %}


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/821

These would usually go to Semantic Scholar, unless the list only contains one article.
Even so, the response times increased and this will at least load the page.
And crawlers will less likely hit Semantic Scholar.
Whereas at the same time, there will be less internal links.