### PR TITLE
Load test API related articles and pass cache control headers to follow-up request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,14 @@ DOCKER_PYTHON = $(DOCKER_RUN) python
 ARGS =
 PYTEST_WATCH_MODULES = tests/unit_tests
 
-LOCUST_FILE = tests/load_tests/homepage_test.py
+LOCUST_FILE =
+
+
+.require-%:
+	@ if [ "${${*}}" = "" ]; then \
+			echo "Environment variable $* not set"; \
+			exit 1; \
+	fi
 
 
 venv-clean:
@@ -73,7 +80,7 @@ dev-start:
 		--log-config=config/logging.yaml
 
 
-dev-start-load-test-ui:
+dev-start-load-test-ui: .require-LOCUST_FILE
 	PYTHONWARNINGS="ignore:Unverified HTTPS request" \
 	$(PYTHON) -m locust \
 		--modern-ui \

--- a/sciety_labs/app/routers/api/article_recommendation.py
+++ b/sciety_labs/app/routers/api/article_recommendation.py
@@ -24,6 +24,7 @@ from sciety_labs.providers.opensearch_article_recommendation import (
     DEFAULT_OPENSEARCH_MAX_RECOMMENDATIONS
 )
 from sciety_labs.utils.datetime import get_date_as_isoformat
+from sciety_labs.utils.fastapi import get_cache_control_headers_for_request
 
 
 LOGGER = logging.getLogger(__name__)
@@ -178,7 +179,8 @@ def create_api_article_recommendation_router(
             }
         }
     )
-    def like_s2_recommendations_for_paper(
+    def like_s2_recommendations_for_paper(  # pylint: disable=too-many-arguments
+        request: fastapi.Request,
         article_doi: str = fastapi.Path(
             alias='DOI',
             description=textwrap.dedent(
@@ -265,7 +267,8 @@ def create_api_article_recommendation_router(
                 [article_doi],
                 app_providers_and_models=app_providers_and_models,
                 filter_parameters=filter_parameters,
-                max_recommendations=limit
+                max_recommendations=limit,
+                headers=get_cache_control_headers_for_request(request)
             )
         except requests.exceptions.RequestException as exception:
             status_code = exception.response.status_code if exception.response else 500

--- a/sciety_labs/app/utils/recommendation.py
+++ b/sciety_labs/app/utils/recommendation.py
@@ -24,7 +24,7 @@ def get_article_recommendation_list_for_article_dois(
     app_providers_and_models: AppProvidersAndModels,
     filter_parameters: Optional[ArticleRecommendationFilterParameters] = None,
     max_recommendations: Optional[int] = None,
-    headers: Optional[Mapping[str, str]] = None  # pylint: disable=unused-argument
+    headers: Optional[Mapping[str, str]] = None
 ) -> ArticleRecommendationList:
     if len(article_dois) == 1 and app_providers_and_models.single_article_recommendation_provider:
         LOGGER.info('Retrieving single article recommendation')
@@ -33,7 +33,8 @@ def get_article_recommendation_list_for_article_dois(
             .single_article_recommendation_provider.get_article_recommendation_list_for_article_doi(
                 article_doi=article_dois[0],
                 max_recommendations=max_recommendations,
-                filter_parameters=filter_parameters
+                filter_parameters=filter_parameters,
+                headers=headers
             )
         )
     else:

--- a/sciety_labs/app/utils/recommendation.py
+++ b/sciety_labs/app/utils/recommendation.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Sequence, Tuple
+from typing import Mapping, Optional, Sequence, Tuple
 
 from sciety_labs.app.app_providers_and_models import AppProvidersAndModels
 from sciety_labs.models.article import ArticleMention, iter_preprint_article_mention
@@ -23,7 +23,8 @@ def get_article_recommendation_list_for_article_dois(
     article_dois: Sequence[str],
     app_providers_and_models: AppProvidersAndModels,
     filter_parameters: Optional[ArticleRecommendationFilterParameters] = None,
-    max_recommendations: Optional[int] = None
+    max_recommendations: Optional[int] = None,
+    headers: Optional[Mapping[str, str]] = None  # pylint: disable=unused-argument
 ) -> ArticleRecommendationList:
     if len(article_dois) == 1 and app_providers_and_models.single_article_recommendation_provider:
         LOGGER.info('Retrieving single article recommendation')

--- a/sciety_labs/providers/article_recommendation.py
+++ b/sciety_labs/providers/article_recommendation.py
@@ -1,6 +1,6 @@
 import dataclasses
 from datetime import date, datetime
-from typing import Iterable, Optional, Protocol, Sequence, Set
+from typing import Iterable, Mapping, Optional, Protocol, Sequence, Set
 
 from sciety_labs.models.article import ArticleMention
 
@@ -37,6 +37,7 @@ class SingleArticleRecommendationProvider(Protocol):
         self,
         article_doi: str,
         max_recommendations: Optional[int] = None,
-        filter_parameters: Optional[ArticleRecommendationFilterParameters] = None
+        filter_parameters: Optional[ArticleRecommendationFilterParameters] = None,
+        headers: Optional[Mapping[str, str]] = None
     ) -> ArticleRecommendationList:
         pass

--- a/sciety_labs/providers/crossref.py
+++ b/sciety_labs/providers/crossref.py
@@ -159,10 +159,14 @@ class CrossrefMetaDataProvider(RequestsProvider):
     def get_crossref_metadata_dict_by_doi(
         self,
         doi: str,
-        headers: Optional[Mapping[str, str]] = None  # pylint: disable=unused-argument
+        headers: Optional[Mapping[str, str]] = None
     ) -> dict:
         url = f'https://api.crossref.org/works/{doi}'
-        response = self.requests_session.get(url, headers=self.headers, timeout=self.timeout)
+        response = self.requests_session.get(
+            url,
+            headers=self.get_headers(headers=headers),
+            timeout=self.timeout
+        )
         response.raise_for_status()
         return response.json()['message']
 

--- a/sciety_labs/providers/crossref.py
+++ b/sciety_labs/providers/crossref.py
@@ -171,7 +171,11 @@ class CrossrefMetaDataProvider(RequestsProvider):
         response.raise_for_status()
         return get_response_dict_by_doi_map(response.json())
 
-    def get_article_metadata_by_doi(self, doi: str) -> ArticleMetaData:
+    def get_article_metadata_by_doi(
+        self,
+        doi: str,
+        headers: Optional[Mapping[str, str]] = None  # pylint: disable=unused-argument
+    ) -> ArticleMetaData:
         return get_article_metadata_from_crossref_metadata(
             doi,
             self.get_crossref_metadata_dict_by_doi(doi)

--- a/sciety_labs/providers/crossref.py
+++ b/sciety_labs/providers/crossref.py
@@ -156,7 +156,11 @@ class CrossrefMetaDataProvider(RequestsProvider):
         super().__init__(**kwargs)
         self.headers['accept'] = 'application/json'
 
-    def get_crossref_metadata_dict_by_doi(self, doi: str) -> dict:
+    def get_crossref_metadata_dict_by_doi(
+        self,
+        doi: str,
+        headers: Optional[Mapping[str, str]] = None  # pylint: disable=unused-argument
+    ) -> dict:
         url = f'https://api.crossref.org/works/{doi}'
         response = self.requests_session.get(url, headers=self.headers, timeout=self.timeout)
         response.raise_for_status()
@@ -174,11 +178,11 @@ class CrossrefMetaDataProvider(RequestsProvider):
     def get_article_metadata_by_doi(
         self,
         doi: str,
-        headers: Optional[Mapping[str, str]] = None  # pylint: disable=unused-argument
+        headers: Optional[Mapping[str, str]] = None
     ) -> ArticleMetaData:
         return get_article_metadata_from_crossref_metadata(
             doi,
-            self.get_crossref_metadata_dict_by_doi(doi)
+            self.get_crossref_metadata_dict_by_doi(doi, headers=headers),
         )
 
     def iter_article_mention_with_article_meta(

--- a/sciety_labs/providers/opensearch_article_recommendation.py
+++ b/sciety_labs/providers/opensearch_article_recommendation.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from datetime import date, timedelta
-from typing import Any, Iterable, Optional, Sequence, cast
+from typing import Any, Iterable, Mapping, Optional, Sequence, cast
 
 from typing_extensions import NotRequired, TypedDict
 
@@ -330,7 +330,8 @@ class OpenSearchArticleRecommendation(SingleArticleRecommendationProvider):
         self,
         article_doi: str,
         max_recommendations: Optional[int] = None,
-        filter_parameters: Optional[ArticleRecommendationFilterParameters] = None
+        filter_parameters: Optional[ArticleRecommendationFilterParameters] = None,
+        headers: Optional[Mapping[str, str]] = None  # pylint: disable=unused-argument
     ) -> ArticleRecommendationList:
         if not max_recommendations:
             max_recommendations = DEFAULT_OPENSEARCH_MAX_RECOMMENDATIONS

--- a/sciety_labs/providers/opensearch_article_recommendation.py
+++ b/sciety_labs/providers/opensearch_article_recommendation.py
@@ -319,6 +319,7 @@ class OpenSearchArticleRecommendation(SingleArticleRecommendationProvider):
     def get_alternative_embedding_vector_for_article_doi_via_title_and_abstract(
         self,
         article_doi: str,
+        headers: Optional[Mapping[str, str]] = None  # pylint: disable=unused-argument
     ) -> Optional[Sequence[float]]:
         article_meta = self.crossref_metadata_provider.get_article_metadata_by_doi(article_doi)
         if not article_meta.article_title or not article_meta.abstract:
@@ -344,7 +345,8 @@ class OpenSearchArticleRecommendation(SingleArticleRecommendationProvider):
         if embedding_vector is None:
             embedding_vector = (
                 self.get_alternative_embedding_vector_for_article_doi_via_title_and_abstract(
-                    article_doi
+                    article_doi,
+                    headers=headers
                 )
             )
         if embedding_vector is None:

--- a/sciety_labs/providers/opensearch_article_recommendation.py
+++ b/sciety_labs/providers/opensearch_article_recommendation.py
@@ -273,7 +273,7 @@ class OpenSearchArticleRecommendation(SingleArticleRecommendationProvider):
         source_includes: Sequence[str],
         max_results: int,
         filter_parameters: ArticleRecommendationFilterParameters,
-        headers: Optional[Mapping[str, str]] = None  # pylint: disable=unused-argument
+        headers: Optional[Mapping[str, str]] = None
     ) -> Sequence[dict]:
         search_query = get_vector_search_query(
             query_vector=query_vector,
@@ -295,13 +295,15 @@ class OpenSearchArticleRecommendation(SingleArticleRecommendationProvider):
 
     def get_embedding_vector_for_article_doi(
         self,
-        article_doi: str
+        article_doi: str,
+        headers: Optional[Mapping[str, str]] = None
     ) -> Optional[Sequence[float]]:
         try:
             doc = self.opensearch_client.get_source(
                 index=self.index_name,
                 id=article_doi,
-                _source_includes=[self.embedding_vector_mapping_name]
+                _source_includes=[self.embedding_vector_mapping_name],
+                headers=headers
             )
         except opensearchpy.exceptions.NotFoundError:
             doc = None
@@ -338,7 +340,7 @@ class OpenSearchArticleRecommendation(SingleArticleRecommendationProvider):
         if not max_recommendations:
             max_recommendations = DEFAULT_OPENSEARCH_MAX_RECOMMENDATIONS
         LOGGER.info('max_recommendations: %r', max_recommendations)
-        embedding_vector = self.get_embedding_vector_for_article_doi(article_doi)
+        embedding_vector = self.get_embedding_vector_for_article_doi(article_doi, headers=headers)
         if embedding_vector is None:
             embedding_vector = (
                 self.get_alternative_embedding_vector_for_article_doi_via_title_and_abstract(

--- a/sciety_labs/providers/opensearch_article_recommendation.py
+++ b/sciety_labs/providers/opensearch_article_recommendation.py
@@ -286,7 +286,8 @@ class OpenSearchArticleRecommendation(SingleArticleRecommendationProvider):
             self.opensearch_client.search(  # pylint: disable=unexpected-keyword-arg
                 body=search_query,
                 index=index,
-                _source_includes=source_includes
+                _source_includes=source_includes,
+                headers=headers
             )
         )
         hits = client_search_results['hits']['hits'][:max_results]

--- a/sciety_labs/providers/opensearch_article_recommendation.py
+++ b/sciety_labs/providers/opensearch_article_recommendation.py
@@ -272,7 +272,8 @@ class OpenSearchArticleRecommendation(SingleArticleRecommendationProvider):
         embedding_vector_mapping_name: str,
         source_includes: Sequence[str],
         max_results: int,
-        filter_parameters: ArticleRecommendationFilterParameters
+        filter_parameters: ArticleRecommendationFilterParameters,
+        headers: Optional[Mapping[str, str]] = None  # pylint: disable=unused-argument
     ) -> Sequence[dict]:
         search_query = get_vector_search_query(
             query_vector=query_vector,
@@ -331,7 +332,7 @@ class OpenSearchArticleRecommendation(SingleArticleRecommendationProvider):
         article_doi: str,
         max_recommendations: Optional[int] = None,
         filter_parameters: Optional[ArticleRecommendationFilterParameters] = None,
-        headers: Optional[Mapping[str, str]] = None  # pylint: disable=unused-argument
+        headers: Optional[Mapping[str, str]] = None
     ) -> ArticleRecommendationList:
         if not max_recommendations:
             max_recommendations = DEFAULT_OPENSEARCH_MAX_RECOMMENDATIONS
@@ -367,7 +368,8 @@ class OpenSearchArticleRecommendation(SingleArticleRecommendationProvider):
                 self.embedding_vector_mapping_name,
             ],
             max_results=max_recommendations,
-            filter_parameters=filter_parameters
+            filter_parameters=filter_parameters,
+            headers=headers
         )
         LOGGER.debug('hits: %r', hits)
         recommendations = list(iter_article_recommendation_from_opensearch_hits(

--- a/sciety_labs/providers/opensearch_article_recommendation.py
+++ b/sciety_labs/providers/opensearch_article_recommendation.py
@@ -281,7 +281,7 @@ class OpenSearchArticleRecommendation(SingleArticleRecommendationProvider):
             max_results=max_results,
             filter_parameters=filter_parameters
         )
-        LOGGER.info('search_query JSON: %s', json.dumps(search_query))
+        LOGGER.info('search_query JSON: %s (headers=%r)', json.dumps(search_query), headers)
         client_search_results = (
             self.opensearch_client.search(  # pylint: disable=unexpected-keyword-arg
                 body=search_query,

--- a/sciety_labs/providers/opensearch_article_recommendation.py
+++ b/sciety_labs/providers/opensearch_article_recommendation.py
@@ -319,9 +319,12 @@ class OpenSearchArticleRecommendation(SingleArticleRecommendationProvider):
     def get_alternative_embedding_vector_for_article_doi_via_title_and_abstract(
         self,
         article_doi: str,
-        headers: Optional[Mapping[str, str]] = None  # pylint: disable=unused-argument
+        headers: Optional[Mapping[str, str]] = None
     ) -> Optional[Sequence[float]]:
-        article_meta = self.crossref_metadata_provider.get_article_metadata_by_doi(article_doi)
+        article_meta = self.crossref_metadata_provider.get_article_metadata_by_doi(
+            article_doi,
+            headers=headers
+        )
         if not article_meta.article_title or not article_meta.abstract:
             LOGGER.info('No title or abstract available to get embedding vector')
             return None

--- a/sciety_labs/providers/opensearch_article_recommendation.py
+++ b/sciety_labs/providers/opensearch_article_recommendation.py
@@ -331,7 +331,8 @@ class OpenSearchArticleRecommendation(SingleArticleRecommendationProvider):
         LOGGER.info('Retrieving embedding vector via title and abstract')
         return self.title_abstract_embedding_vector_provider.get_embedding_vector(
             title=article_meta.article_title,
-            abstract=article_meta.abstract
+            abstract=article_meta.abstract,
+            headers=headers
         )
 
     def get_article_recommendation_list_for_article_doi(

--- a/sciety_labs/providers/requests_provider.py
+++ b/sciety_labs/providers/requests_provider.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Mapping, Optional
 
 import requests
 
@@ -8,10 +8,21 @@ class RequestsProvider:
         self,
         requests_session: Optional[requests.Session] = None
     ) -> None:
-        self.headers: dict = {
+        self.headers: Dict[str, str] = {
             'User-Agent': 'Sciety Labs; +https://github.com/sciety/sciety-labs'
         }
         if requests_session is None:
             requests_session = requests.Session()
         self.requests_session = requests_session
         self.timeout: float = 5 * 60
+
+    def get_headers(
+        self,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Mapping[str, str]:
+        if headers:
+            return {
+                **headers,
+                **self.headers
+            }
+        return self.headers

--- a/sciety_labs/providers/semantic_scholar.py
+++ b/sciety_labs/providers/semantic_scholar.py
@@ -377,7 +377,12 @@ class SemanticScholarSearchProvider(SearchProvider):
 
 
 class SemanticScholarTitleAbstractEmbeddingVectorProvider(RequestsProvider):
-    def get_embedding_vector(self, title: str, abstract: str) -> Sequence[float]:
+    def get_embedding_vector(
+        self,
+        title: str,
+        abstract: str,
+        headers: Optional[Mapping[str, str]] = None
+    ) -> Sequence[float]:
         paper_id = '_dummy_paper_id'
         papers = [{
             'paper_id': paper_id,
@@ -387,7 +392,8 @@ class SemanticScholarTitleAbstractEmbeddingVectorProvider(RequestsProvider):
         response = requests.post(
             'https://model-apis.semanticscholar.org/specter/v1/invoke',
             json=papers,
-            timeout=self.timeout
+            timeout=self.timeout,
+            headers=self.get_headers(headers=headers)
         )
         response.raise_for_status()
         embeddings_by_paper_id = {

--- a/sciety_labs/utils/fastapi.py
+++ b/sciety_labs/utils/fastapi.py
@@ -1,5 +1,5 @@
 import ipaddress
-from typing import Optional
+from typing import Mapping, Optional
 
 from fastapi import Request
 
@@ -40,3 +40,12 @@ async def update_request_scope_to_original_url_middleware(
 ):
     update_request_scope_to_original_url(request)
     return await call_next(request)
+
+
+def get_cache_control_headers_for_request(
+    request: Request
+) -> Mapping[str, str]:
+    cache_control = request.headers.get('Cache-Control')
+    if not cache_control:
+        return {}
+    return {'Cache-Control': cache_control}

--- a/tests/load_tests/api_related_article_test.py
+++ b/tests/load_tests/api_related_article_test.py
@@ -20,10 +20,16 @@ TEST_API_PARAMS_1 = {
 }
 
 
+NO_CACHE_HEADERS = {
+    'Cache-Control': 'no-store'
+}
+
+
 class ScietyLabsApiRelatedArticlesUser(HttpUser):
     @task
     def related_articles(self):
         self.client.get(
             f'/api/like/s2/recommendations/v1/papers/forpaper/DOI:{TEST_DOI_1}',
-            params=TEST_API_PARAMS_1
+            params=TEST_API_PARAMS_1,
+            headers=NO_CACHE_HEADERS
         )

--- a/tests/load_tests/api_related_article_test.py
+++ b/tests/load_tests/api_related_article_test.py
@@ -1,0 +1,29 @@
+from locust import HttpUser, task
+
+
+TEST_DOI_1 = '10.1101/2023.05.01.538996'
+
+TEST_FIELDS_1 = {
+    'externalIds',
+    'title',
+    'publicationDate',
+    'authors',
+    '_evaluationCount',
+    '_score'
+}
+
+TEST_API_PARAMS_1 = {
+    'fields': ','.join(sorted(TEST_FIELDS_1)),
+    '_evaluated_only': 'false',
+    '_published_within_last_n_days': 60,
+    'limit': 3
+}
+
+
+class ScietyLabsApiRelatedArticlesUser(HttpUser):
+    @task
+    def related_articles(self):
+        self.client.get(
+            f'/api/like/s2/recommendations/v1/papers/forpaper/DOI:{TEST_DOI_1}',
+            params=TEST_API_PARAMS_1
+        )

--- a/tests/unit_tests/app/routers/api/article_recommendation_test.py
+++ b/tests/unit_tests/app/routers/api/article_recommendation_test.py
@@ -168,7 +168,8 @@ class TestArticleRecommendationApi:
             [DOI_1],
             app_providers_and_models=app_providers_and_models_mock,
             filter_parameters=ANY,
-            max_recommendations=None
+            max_recommendations=None,
+            headers=ANY
         )
 
     def test_should_format_recommendation_response(

--- a/tests/unit_tests/utils/fastapi_test.py
+++ b/tests/unit_tests/utils/fastapi_test.py
@@ -6,6 +6,7 @@ import starlette.datastructures
 import starlette.types
 
 from sciety_labs.utils.fastapi import (
+    get_cache_control_headers_for_request,
     get_likely_client_ip_for_request,
     update_request_scope_to_original_url
 )
@@ -114,3 +115,23 @@ class TestUpdateRequestScopeToOriginalUrl:
         })
         update_request_scope_to_original_url(request_mock)
         assert request_mock.scope['scheme'] == 'https'
+
+
+class TestGetCacheControlHeadersForRequest:
+    def test_should_return_empty_dict_without_cache_control_in_headers(
+        self,
+        request_mock: MagicMock
+    ):
+        request_mock.headers = starlette.datastructures.Headers({})
+        assert not get_cache_control_headers_for_request(request_mock)
+
+    def test_should_return_cache_control_from_headers(
+        self,
+        request_mock: MagicMock
+    ):
+        request_mock.headers = starlette.datastructures.Headers({
+            'Cache-Control': 'no-store'
+        })
+        assert get_cache_control_headers_for_request(request_mock) == {
+            'Cache-Control': 'no-store'
+        }


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/818

This is adding load tests for the related articles API.
As that is using the same DOI, it is passing cache control headers in that the API is then passing on to follow-up requests.