### PR TITLE
Updated TemplateResponse due to deprecation warning

### DIFF
--- a/sciety_labs/app/main.py
+++ b/sciety_labs/app/main.py
@@ -111,8 +111,9 @@ def create_app():  # pylint: disable=too-many-locals, too-many-statements
     @app.exception_handler(404)
     async def not_found_exception_handler(request: Request, exception: HTTPException):
         return templates.TemplateResponse(
-            'errors/404.html', {
-                'request': request,
+            request=request,
+            name='errors/404.html',
+            context={
                 'page_title': get_page_title('Page not found'),
                 'exception': exception
             },
@@ -122,8 +123,9 @@ def create_app():  # pylint: disable=too-many-locals, too-many-statements
     @app.exception_handler(500)
     async def server_error_exception_handler(request: Request, exception: HTTPException):
         return templates.TemplateResponse(
-            'errors/500.html', {
-                'request': request,
+            request=request,
+            name='errors/500.html',
+            context={
                 'page_title': get_page_title('Something went wrong'),
                 'exception': exception
             },

--- a/sciety_labs/app/routers/articles.py
+++ b/sciety_labs/app/routers/articles.py
@@ -1,6 +1,6 @@
 from datetime import date, timedelta
 import logging
-from typing import Optional
+from typing import Any, Dict, Optional, cast
 
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
@@ -175,11 +175,14 @@ def create_articles_router(
         return templates.TemplateResponse(
             request=request,
             name='fragments/article-recommendations.html',
-            context={
-                'article_list_content': article_recommendation_with_article_meta,
-                'pagination': url_pagination_state,
-                'article_recommendation_url': article_recommendation_url
-            }
+            context=cast(
+                Dict[str, Any],  # workaround for mypy false positive
+                {
+                    'article_list_content': article_recommendation_with_article_meta,
+                    'pagination': url_pagination_state,
+                    'article_recommendation_url': article_recommendation_url
+                }
+            )
         )
 
     return router

--- a/sciety_labs/app/routers/articles.py
+++ b/sciety_labs/app/routers/articles.py
@@ -62,8 +62,9 @@ def create_articles_router(
             if status_code != 404:
                 raise
             return templates.TemplateResponse(
-                'errors/error.html', {
-                    'request': request,
+                request=request,
+                name='errors/error.html',
+                context={
                     'page_title': get_page_title(f'Article not found: {article_doi}'),
                     'error_message': f'Article not found: {article_doi}',
                     'exception': exception
@@ -94,8 +95,9 @@ def create_articles_router(
         LOGGER.info('article_recommendation_fragment_url: %r', article_recommendation_fragment_url)
 
         return templates.TemplateResponse(
-            'pages/article-by-article-doi.html', {
-                'request': request,
+            request=request,
+            name='pages/article-by-article-doi.html',
+            context={
                 'page_title': get_page_title(article_meta.article_title),
                 'page_description': remove_markup_or_none(
                     article_meta.abstract
@@ -124,8 +126,9 @@ def create_articles_router(
                 request.url.include_query_params(fragment=True)
             )
             return templates.TemplateResponse(
-                'pages/article-recommendations-by-article-doi.html', {
-                    'request': request,
+                request=request,
+                name='pages/article-recommendations-by-article-doi.html',
+                context={
                     'page_title': get_page_title(
                         f'Article recommendations for {article_meta.article_title}'
                     ),
@@ -170,8 +173,9 @@ def create_articles_router(
         )
         LOGGER.info('url_pagination_state: %r', url_pagination_state)
         return templates.TemplateResponse(
-            'fragments/article-recommendations.html', {
-                'request': request,
+            request=request,
+            name='fragments/article-recommendations.html',
+            context={
                 'article_list_content': article_recommendation_with_article_meta,
                 'pagination': url_pagination_state,
                 'article_recommendation_url': article_recommendation_url

--- a/sciety_labs/app/routers/home.py
+++ b/sciety_labs/app/routers/home.py
@@ -42,8 +42,9 @@ def create_home_router(
         )
         LOGGER.info('group_list_summary_data_list: %r', group_list_summary_data_list)
         return templates.TemplateResponse(
-            'pages/index.html', {
-                'request': request,
+            request=request,
+            name='pages/index.html',
+            context={
                 'user_lists': user_list_summary_data_list,
                 'group_lists': group_list_summary_data_list,
                 'search_feeds': list(search_feeds_config.feeds_by_slug.values())[:3]

--- a/sciety_labs/app/routers/list_by_id.py
+++ b/sciety_labs/app/routers/list_by_id.py
@@ -65,8 +65,9 @@ def create_list_by_id_router(
             item_count=item_count
         )
         return templates.TemplateResponse(
-            'pages/list-by-sciety-list-id.html', {
-                'request': request,
+            request=request,
+            name='pages/list-by-sciety-list-id.html',
+            context={
                 'page_title': get_page_title(list_summary_data.list_meta.list_name),
                 'page_description': remove_markup_or_none(
                     list_summary_data.list_meta.list_description
@@ -99,8 +100,9 @@ def create_list_by_id_router(
             )
         )
         return templates.TemplateResponse(
-            'pages/list-by-sciety-list-id.atom.xml', {
-                'request': request,
+            request=request,
+            name='pages/list-by-sciety-list-id.atom.xml',
+            context={
                 'list_summary_data': list_summary_data,
                 'article_list_content': article_mention_with_article_meta
             },
@@ -126,8 +128,9 @@ def create_list_by_id_router(
                 request.url.include_query_params(fragment=True)
             )
             return templates.TemplateResponse(
-                'pages/article-recommendations-by-sciety-list-id.html', {
-                    'request': request,
+                request=request,
+                name='pages/article-recommendations-by-sciety-list-id.html',
+                context={
                     'page_title': get_page_title(
                         f'Article recommendations for {list_summary_data.list_meta.list_name}'
                     ),
@@ -159,8 +162,9 @@ def create_list_by_id_router(
             item_count=item_count
         )
         return templates.TemplateResponse(
-            'fragments/article-recommendations.html', {
-                'request': request,
+            request=request,
+            name='fragments/article-recommendations.html',
+            context={
                 'page_title': get_page_title(
                     f'Article recommendations for {list_summary_data.list_meta.list_name}'
                 ),
@@ -214,8 +218,9 @@ def create_list_by_id_router(
         )
         LOGGER.info('recommendation_timestamp: %r', recommendation_timestamp)
         return templates.TemplateResponse(
-            'pages/article-recommendations-by-sciety-list-id.atom.xml', {
-                'request': request,
+            request=request,
+            name='pages/article-recommendations-by-sciety-list-id.atom.xml',
+            context={
                 'feed_title': (
                     f'Article recommendations for {list_summary_data.list_meta.list_name}'
                 ),

--- a/sciety_labs/app/routers/list_by_twitter_handle.py
+++ b/sciety_labs/app/routers/list_by_twitter_handle.py
@@ -60,8 +60,9 @@ def create_list_by_twitter_handle_router(
             remaining_item_iterable=article_mention_iterable
         )
         return templates.TemplateResponse(
-            'pages/list-by-twitter-handle.html', {
-                'request': request,
+            request=request,
+            name='pages/list-by-twitter-handle.html',
+            context={
                 'page_title': get_page_title(
                     f'Twitter curations by {twitter_user.name} (@{twitter_handle})'
                 ),

--- a/sciety_labs/app/routers/lists.py
+++ b/sciety_labs/app/routers/lists.py
@@ -52,8 +52,9 @@ def create_lists_router(
         )
         LOGGER.info('group_list_summary_data_list[:1]=%r', group_list_summary_data_list[:1])
         return templates.TemplateResponse(
-            'pages/lists.html', {
-                'request': request,
+            request=request,
+            name='pages/lists.html',
+            context={
                 'page_title': page_title,
                 'user_lists': user_list_summary_data_list,
                 'group_lists': group_list_summary_data_list

--- a/sciety_labs/app/routers/search.py
+++ b/sciety_labs/app/routers/search.py
@@ -249,10 +249,11 @@ def create_search_router(
             pagination_parameters=pagination_parameters
         )
         return templates.TemplateResponse(
-            'pages/search.html', {
+            request=request,
+            name='pages/search.html',
+            context={
                 **get_search_parameters_template_parameters(search_parameters),
                 **get_search_result_template_parameters(search_result_page),
-                'request': request,
                 'page_title': (
                     f'Search results for {search_parameters.query}'
                     if search_parameters.query else 'Search'
@@ -273,12 +274,13 @@ def create_search_router(
             pagination_parameters=pagination_parameters
         )
         return templates.TemplateResponse(
-            'pages/search-feed.html', {
+            request=request,
+            name='pages/search-feed.html',
+            context={
                 **get_search_parameters_template_parameters(
                     search_feed_parameters.search_parameters
                 ),
                 **get_search_result_template_parameters(search_result_page),
-                'request': request,
                 'page_title': search_feed_parameters.page_title,
                 'page_description': search_feed_parameters.page_description,
                 'page_images': search_feed_parameters.feed_images,
@@ -299,12 +301,13 @@ def create_search_router(
             pagination_parameters=pagination_parameters
         )
         return templates.TemplateResponse(
-            'pages/search-feed.atom.xml', {
+            request=request,
+            name='pages/search-feed.atom.xml',
+            context={
                 **get_search_parameters_template_parameters(
                     search_feed_parameters.search_parameters
                 ),
                 **get_search_result_template_parameters(search_result_page),
-                'request': request,
                 'last_updated_timestamp': get_rss_updated_timestamp(
                     search_result_page.search_result_list_with_article_meta
                 ),
@@ -322,8 +325,9 @@ def create_search_router(
         request: Request
     ):
         return templates.TemplateResponse(
-            'pages/search-feeds.html', {
-                'request': request,
+            request=request,
+            name='pages/search-feeds.html',
+            context={
                 'page_title': get_page_title('Feeds'),
                 'search_feeds': search_feeds_config.feeds_by_slug.values()
             }


### PR DESCRIPTION
The parameters for `TemplateResponse` changed. `request` is now meant to be passed in as the first parameter rather than as part of the context. Switched to using keyword arguments to avoid confusion.