### PR TITLE
Fixed Related Articles for Title and Abstract with requests cache

### DIFF
--- a/sciety_labs/providers/opensearch.py
+++ b/sciety_labs/providers/opensearch.py
@@ -8,6 +8,7 @@ from typing import Any, Collection, Mapping, Type, Union, cast, Optional
 
 
 from opensearchpy import OpenSearch, Transport
+import opensearchpy
 
 import requests
 
@@ -137,6 +138,8 @@ class OpenSearchTransport(Transport):
                 response.status_code,
                 (end_time - start_time)
             )
+            if response.status_code == 404:
+                raise opensearchpy.exceptions.NotFoundError(f'Not found: {full_url}')
             response.raise_for_status()
             return response.json()
         return super().perform_request(


### PR DESCRIPTION
When using a requests cache, it was throwing 'requests.exception.HTTPError` instead of the `opensearchpy.exceptions.NotFoundError`. Causing it to not provide any related articles instead of falling back to title and abstract.

Example DOI: `10.21203/rs.3.rs-3609799/v1`