### PR TITLE
Redirect for url encoded double query parameters

### DIFF
--- a/sciety_labs/utils/uvicorn.py
+++ b/sciety_labs/utils/uvicorn.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Optional
 
 from starlette.datastructures import URL
@@ -12,7 +13,7 @@ LOGGER = logging.getLogger(__name__)
 def get_redirect_url_for_double_query_string_url_or_none(url: URL) -> Optional[str]:
     LOGGER.info('url.query: %r', url.query)
     if url.query:
-        first_query_string, *other_query_strings = url.query.split('?', maxsplit=1)
+        first_query_string, *other_query_strings = re.split(r'\?|%3F', url.query, maxsplit=1)
         if other_query_strings:
             return str(url.replace(query=first_query_string))
     return None

--- a/sciety_labs/utils/uvicorn.py
+++ b/sciety_labs/utils/uvicorn.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def get_redirect_url_for_double_query_string_url_or_none(url: URL) -> Optional[str]:
-    LOGGER.info('url.query: %r', url.query)
+    LOGGER.debug('url.query: %r', url.query)
     if url.query:
         first_query_string, *other_query_strings = re.split(r'\?|%3F', url.query, maxsplit=1)
         if other_query_strings:

--- a/sciety_labs/utils/uvicorn.py
+++ b/sciety_labs/utils/uvicorn.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from starlette.datastructures import URL
 from starlette.responses import RedirectResponse
@@ -6,6 +7,15 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+def get_redirect_url_for_double_query_string_url_or_none(url: URL) -> Optional[str]:
+    LOGGER.info('url.query: %r', url.query)
+    if url.query:
+        first_query_string, *other_query_strings = url.query.split('?', maxsplit=1)
+        if other_query_strings:
+            return str(url.replace(query=first_query_string))
+    return None
 
 
 class RedirectDoubleQueryStringMiddleware:
@@ -18,14 +28,12 @@ class RedirectDoubleQueryStringMiddleware:
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         LOGGER.debug('scope: %r', scope)
         url = URL(scope=scope)
-        if url.query:
-            first_query_string, *other_query_strings = url.query.split('?', maxsplit=1)
-            if other_query_strings:
-                redirect_url = str(url.replace(query=first_query_string))
-                LOGGER.info('Redirecting to (due to double query string): %r', redirect_url)
-                response = RedirectResponse(url=redirect_url, status_code=301)
-                await response(scope, receive, send)
-                return
+        redirect_url = get_redirect_url_for_double_query_string_url_or_none(url)
+        if redirect_url:
+            LOGGER.info('Redirecting to (due to double query string): %r', redirect_url)
+            response = RedirectResponse(url=redirect_url, status_code=301)
+            await response(scope, receive, send)
+            return
         await self.app(scope, receive, send)
 
 

--- a/tests/unit_tests/utils/uvicorn_test.py
+++ b/tests/unit_tests/utils/uvicorn_test.py
@@ -1,0 +1,32 @@
+from starlette.datastructures import URL
+
+from sciety_labs.utils.uvicorn import get_redirect_url_for_double_query_string_url_or_none
+
+
+BASE_URL_1 = 'https://localhost/path/to'
+
+
+class TestGetRedirectUrlForDoubleQueryStringUrlOrNone:
+    def test_should_return_none_for_url_with_no_query_parameters(self):
+        redirect_url = get_redirect_url_for_double_query_string_url_or_none(
+            URL(BASE_URL_1)
+        )
+        assert redirect_url is None
+
+    def test_should_return_none_for_url_with_regular_query_parameters(self):
+        redirect_url = get_redirect_url_for_double_query_string_url_or_none(
+            URL(f'{BASE_URL_1}?param1=1&param2=2')
+        )
+        assert redirect_url is None
+
+    def test_should_return_url_without_duplicate_query_parameters(self):
+        redirect_url = get_redirect_url_for_double_query_string_url_or_none(
+            URL(f'{BASE_URL_1}?param1=1&param2=2?param1=1&param2=2')
+        )
+        assert redirect_url == f'{BASE_URL_1}?param1=1&param2=2'
+
+    def test_should_return_url_without_duplicate_url_encoded_query_parameters(self):
+        redirect_url = get_redirect_url_for_double_query_string_url_or_none(
+            URL(f'{BASE_URL_1}?param1=1&param2=2%3Fparam1%3D1&param2%3D2')
+        )
+        assert redirect_url == f'{BASE_URL_1}?param1=1&param2=2'


### PR DESCRIPTION
Follow up to https://github.com/sciety/sciety-labs/pull/310

Some requests came in with URL encoded parameters, e.g.:

`/article-recommendations/by?article_doi=10.1101%2F2023.10.25.23297562%3Farticle_doi=10.1101%2F2023.10.25.23297562`