### PR TITLE
Made default like s2 API endpoint async

### DIFF
--- a/sciety_labs/app/routers/api/article_recommendation.py
+++ b/sciety_labs/app/routers/api/article_recommendation.py
@@ -293,11 +293,8 @@ def create_api_article_recommendation_router(
     router = APIRouter()
 
     @router.get(
-        '/like/s2/recommendations/v1/papers/forpaper/DOI:{DOI:path}',
-        summary=LIKE_S2_RECOMMENDATION_API_SUMMARY,
-        description=LIKE_S2_RECOMMENDATION_API_DESCRIPTION,
-        response_model=RecommendationResponseDict,
-        responses=LIKE_S2_RECOMMENDATION_API_EXAMPLE_RESPONSES
+        '/sync/like/s2/recommendations/v1/papers/forpaper/DOI:{DOI:path}',
+        include_in_schema=False
     )
     def like_s2_recommendations_for_paper(  # pylint: disable=too-many-arguments
         request: fastapi.Request,
@@ -338,7 +335,7 @@ def create_api_article_recommendation_router(
         )
 
     @router.get(
-        '/async/like/s2/recommendations/v1/papers/forpaper/DOI:{DOI:path}',
+        '/like/s2/recommendations/v1/papers/forpaper/DOI:{DOI:path}',
         summary=LIKE_S2_RECOMMENDATION_API_SUMMARY,
         description=LIKE_S2_RECOMMENDATION_API_DESCRIPTION,
         response_model=RecommendationResponseDict,
@@ -376,6 +373,7 @@ def create_api_article_recommendation_router(
                     headers=get_cache_control_headers_for_request(request)
                 )
             )
+            LOGGER.debug('article_recommendation_list: %r', article_recommendation_list)
         except Exception as exception:  # pylint: disable=broad-exception-caught
             return handle_like_s2_recommendation_exception(
                 exception=exception,

--- a/tests/regression_tests/related_article_api.py
+++ b/tests/regression_tests/related_article_api.py
@@ -1,6 +1,7 @@
 
 
 from requests import Session
+from sciety_labs.app.routers.api.article_recommendation import RecommendationResponseDict
 
 from tests.regression_tests.test_data import DOI_1
 
@@ -11,3 +12,5 @@ class TestRelatedArticlesApi:
             f'/api/like/s2/recommendations/v1/papers/forpaper/DOI:{DOI_1}'
         )
         response.raise_for_status()
+        response_json: RecommendationResponseDict = response.json()
+        assert len(response_json['recommendedPapers']) > 0

--- a/tests/regression_tests/related_article_api.py
+++ b/tests/regression_tests/related_article_api.py
@@ -1,0 +1,13 @@
+
+
+from requests import Session
+
+from tests.regression_tests.test_data import DOI_1
+
+
+class TestRelatedArticlesApi:
+    def test_should_load_related_article_results(self, regression_test_session: Session):
+        response = regression_test_session.get(
+            f'/api/like/s2/recommendations/v1/papers/forpaper/DOI:{DOI_1}'
+        )
+        response.raise_for_status()

--- a/tests/unit_tests/app/routers/conftest.py
+++ b/tests/unit_tests/app/routers/conftest.py
@@ -1,8 +1,31 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+from sciety_labs.providers.async_article_recommendation import (
+    AsyncSingleArticleRecommendationProvider
+)
 
 
 @pytest.fixture(name='app_providers_and_models_mock')
 def _app_providers_and_models_mock() -> MagicMock:
     return MagicMock(name='app_providers_and_models')
+
+
+@pytest.fixture(name='async_single_article_recommendation_provider_mock', autouse=True)
+def _async_single_article_recommendation_provider_mock(
+    app_providers_and_models_mock: MagicMock
+) -> AsyncMock:
+    mock = AsyncMock(AsyncSingleArticleRecommendationProvider)
+    app_providers_and_models_mock.async_single_article_recommendation_provider = mock
+    return mock
+
+
+@pytest.fixture(autouse=True)
+def get_article_recommendation_list_for_article_doi_mock(
+    async_single_article_recommendation_provider_mock: AsyncMock
+) -> AsyncMock:
+    return (
+        async_single_article_recommendation_provider_mock
+        .get_article_recommendation_list_for_article_doi
+    )

--- a/tests/unit_tests/test_utils.py
+++ b/tests/unit_tests/test_utils.py
@@ -1,0 +1,6 @@
+# from unittest.mock import MagicMock
+
+
+# class AsyncMock(MagicMock):
+#     async def __call__(self, *args, **kwargs):
+#         return super(AsyncMock, self).__call__(*args, **kwargs)


### PR DESCRIPTION
The `sync` variant has the `/sync` prefix but isn't shown the API docs anymore.