### PR TITLE
Related Articles API only requesting selected fields from OpenSearch

### DIFF
--- a/sciety_labs/app/routers/api/article_recommendation.py
+++ b/sciety_labs/app/routers/api/article_recommendation.py
@@ -201,8 +201,7 @@ LIKE_S2_RECOMMENDATION_API_PUBLISHED_WITHIN_LAST_N_DAYS_FASTAPI_QUERY = fastapi.
 
 
 REQUIRED_ARTICLE_RECOMMENDATION_FIELDS = [
-    ArticleRecommendationFields.ARTICLE_DOI,
-    ArticleRecommendationFields.ARTICLE_TITLE
+    ArticleRecommendationFields.ARTICLE_DOI
 ]
 
 ARTICLE_RECOMMENDATION_FIELDS_BY_API_FIELD_NAME: Mapping[str, Sequence[str]] = {

--- a/sciety_labs/app/routers/articles.py
+++ b/sciety_labs/app/routers/articles.py
@@ -104,7 +104,7 @@ def create_articles_router(
             request=request,
             name='pages/article-by-article-doi.html',
             context={
-                'page_title': get_page_title(article_meta.article_title),
+                'page_title': get_page_title(article_meta.article_title_or_placeholder),
                 'page_description': remove_markup_or_none(
                     article_meta.abstract
                 ),

--- a/sciety_labs/models/article.py
+++ b/sciety_labs/models/article.py
@@ -93,10 +93,16 @@ def is_preprint_doi(article_doi: str) -> bool:
 
 class ArticleMetaData(NamedTuple):
     article_doi: str
-    article_title: str
+    article_title: Optional[str]
     abstract: Optional[str] = None
     author_name_list: Optional[Sequence[str]] = None
     published_date: Optional[date] = None
+
+    @property
+    def article_title_or_placeholder(self) -> str:
+        if self.article_title:
+            return self.article_title
+        return self.article_doi
 
 
 class ArticleStats(NamedTuple):

--- a/sciety_labs/providers/article_recommendation.py
+++ b/sciety_labs/providers/article_recommendation.py
@@ -1,27 +1,20 @@
 import dataclasses
 from datetime import date, datetime
-from typing import Iterable, Literal, Mapping, Optional, Protocol, Sequence, Set
+from typing import Iterable, Mapping, Optional, Protocol, Sequence, Set
 
 from sciety_labs.models.article import ArticleMention
 
 
 class ArticleRecommendationFields:
-    ARTICLE_DOI = Literal['article_doi']
-    ARTICLE_TITLE = Literal['article_title']
-    AUTHOR_NAME_LIST = Literal['author_name_list']
-    PUBLISHED_DATE = Literal['published_date']
-    EVALUATION_COUNT = Literal['evaluation_count']
-    SCORE = Literal['score']
+    ARTICLE_DOI = 'article_doi'
+    ARTICLE_TITLE = 'article_title'
+    AUTHOR_NAME_LIST = 'author_name_list'
+    PUBLISHED_DATE = 'published_date'
+    EVALUATION_COUNT = 'evaluation_count'
+    SCORE = 'score'
 
 
-ArticleRecommendationFieldLiteral = Literal[
-    ArticleRecommendationFields.ARTICLE_DOI,
-    ArticleRecommendationFields.ARTICLE_TITLE,
-    ArticleRecommendationFields.AUTHOR_NAME_LIST,
-    ArticleRecommendationFields.PUBLISHED_DATE,
-    ArticleRecommendationFields.EVALUATION_COUNT,
-    ArticleRecommendationFields.SCORE
-]
+ArticleRecommendationFieldLiteral = str
 
 
 @dataclasses.dataclass(frozen=True)

--- a/sciety_labs/providers/article_recommendation.py
+++ b/sciety_labs/providers/article_recommendation.py
@@ -1,8 +1,27 @@
 import dataclasses
 from datetime import date, datetime
-from typing import Iterable, Mapping, Optional, Protocol, Sequence, Set
+from typing import Iterable, Literal, Mapping, Optional, Protocol, Sequence, Set
 
 from sciety_labs.models.article import ArticleMention
+
+
+class ArticleRecommendationFields:
+    ARTICLE_DOI = Literal['article_doi']
+    ARTICLE_TITLE = Literal['article_title']
+    AUTHOR_NAME_LIST = Literal['author_name_list']
+    PUBLISHED_DATE = Literal['published_date']
+    EVALUATION_COUNT = Literal['evaluation_count']
+    SCORE = Literal['score']
+
+
+ArticleRecommendationFieldLiteral = Literal[
+    ArticleRecommendationFields.ARTICLE_DOI,
+    ArticleRecommendationFields.ARTICLE_TITLE,
+    ArticleRecommendationFields.AUTHOR_NAME_LIST,
+    ArticleRecommendationFields.PUBLISHED_DATE,
+    ArticleRecommendationFields.EVALUATION_COUNT,
+    ArticleRecommendationFields.SCORE
+]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/sciety_labs/providers/async_article_recommendation.py
+++ b/sciety_labs/providers/async_article_recommendation.py
@@ -1,17 +1,19 @@
-from typing import Mapping, Optional, Protocol
+from typing import Mapping, Optional, Protocol, Sequence
 
 from sciety_labs.providers.article_recommendation import (
+    ArticleRecommendationFieldLiteral,
     ArticleRecommendationFilterParameters,
     ArticleRecommendationList
 )
 
 
 class AsyncSingleArticleRecommendationProvider(Protocol):
-    async def get_article_recommendation_list_for_article_doi(
+    async def get_article_recommendation_list_for_article_doi(  # pylint: disable=too-many-arguments
         self,
         article_doi: str,
         max_recommendations: Optional[int] = None,
         filter_parameters: Optional[ArticleRecommendationFilterParameters] = None,
+        fields: Optional[Sequence[ArticleRecommendationFieldLiteral]] = None,
         headers: Optional[Mapping[str, str]] = None
     ) -> ArticleRecommendationList:
         pass

--- a/sciety_labs/providers/async_opensearch_article_recommendation.py
+++ b/sciety_labs/providers/async_opensearch_article_recommendation.py
@@ -8,6 +8,7 @@ import numpy.typing as npt
 import opensearchpy
 
 from sciety_labs.providers.article_recommendation import (
+    ArticleRecommendationFieldLiteral,
     ArticleRecommendationFilterParameters,
     ArticleRecommendationList
 )
@@ -134,11 +135,12 @@ class AsyncOpenSearchArticleRecommendation(AsyncSingleArticleRecommendationProvi
             headers=headers
         )
 
-    async def get_article_recommendation_list_for_article_doi(
+    async def get_article_recommendation_list_for_article_doi(  # pylint: disable=too-many-arguments
         self,
         article_doi: str,
         max_recommendations: Optional[int] = None,
         filter_parameters: Optional[ArticleRecommendationFilterParameters] = None,
+        fields: Optional[Sequence[ArticleRecommendationFieldLiteral]] = None,
         headers: Optional[Mapping[str, str]] = None
     ) -> ArticleRecommendationList:
         if not max_recommendations:
@@ -188,6 +190,7 @@ class AsyncOpenSearchArticleRecommendation(AsyncSingleArticleRecommendationProvi
             embedding_vector_mapping_name=self.embedding_vector_mapping_name,
             source_includes=get_source_includes(
                 embedding_vector_mapping_name=self.embedding_vector_mapping_name,
+                fields=fields
             ),
             max_results=max_recommendations,
             filter_parameters=filter_parameters,

--- a/sciety_labs/providers/opensearch_article_recommendation.py
+++ b/sciety_labs/providers/opensearch_article_recommendation.py
@@ -182,7 +182,8 @@ def get_article_meta_from_document(
 def get_value_for_key_path(parent: dict, key_path: Sequence[str]) -> Optional[Any]:
     result: Any = parent
     for key in key_path:
-        result = result.get(key)
+        if result is not None:
+            result = result.get(key)
     return result
 
 

--- a/sciety_labs/providers/opensearch_article_recommendation.py
+++ b/sciety_labs/providers/opensearch_article_recommendation.py
@@ -157,7 +157,6 @@ def get_article_meta_from_document(
         or (europepmc_data and europepmc_data.get('title_with_markup'))
         or (s2_data and s2_data.get('title'))
     )
-    assert article_title is not None
     return ArticleMetaData(
         article_doi=article_doi,
         article_title=article_title,

--- a/sciety_labs/providers/opensearch_article_recommendation.py
+++ b/sciety_labs/providers/opensearch_article_recommendation.py
@@ -13,6 +13,8 @@ from sciety_labs.models.article import ArticleMetaData, ArticleStats
 
 from sciety_labs.providers.article_recommendation import (
     ArticleRecommendation,
+    ArticleRecommendationFieldLiteral,
+    ArticleRecommendationFields,
     ArticleRecommendationFilterParameters,
     ArticleRecommendationList,
     SingleArticleRecommendationProvider
@@ -324,19 +326,63 @@ def get_vector_search_query(  # pylint: disable=too-many-arguments
     return search_query
 
 
-def get_source_includes(embedding_vector_mapping_name: str) -> Sequence[str]:
-    return [
-        'doi',
-        'crossref.publication_date',
-        'crossref.title_with_markup',
-        'crossref.author_list',
-        's2.title',
-        's2.author_list',
-        'europepmc.first_publication_date',
-        'europepmc.title_with_markup',
-        'europepmc.author_list',
-        'sciety.evaluation_count',
-        embedding_vector_mapping_name,
+ARTICLE_TITLE_OPENSEARCH_FIELDS = [
+    'crossref.title_with_markup',
+    's2.title',
+    'europepmc.title_with_markup'
+]
+
+AUTHOR_LIST_OPENSEARCH_FIELDS = [
+    'crossref.author_list',
+    's2.author_list',
+    'europepmc.author_list'
+]
+
+PUBLISHED_DATE_OPENSEARCH_FIELDS = [
+    'crossref.publication_date',
+    'europepmc.first_publication_date'
+]
+
+EVALUATION_COUNT_OPENSEARCH_FIELDS = [
+    'sciety.evaluation_count'
+]
+
+
+SUPPORTED_OPENSEARCH_FIELD_NAMES = (
+    ['doi']
+    + ARTICLE_TITLE_OPENSEARCH_FIELDS
+    + AUTHOR_LIST_OPENSEARCH_FIELDS
+    + PUBLISHED_DATE_OPENSEARCH_FIELDS
+    + EVALUATION_COUNT_OPENSEARCH_FIELDS
+)
+
+OPENSEARCH_FIELDS_BY_REQUESTED_FIELD: Mapping[str, Sequence[str]] = {
+    str(ArticleRecommendationFields.ARTICLE_DOI): ['doi'],
+    str(ArticleRecommendationFields.ARTICLE_TITLE): ARTICLE_TITLE_OPENSEARCH_FIELDS,
+    str(ArticleRecommendationFields.AUTHOR_NAME_LIST): AUTHOR_LIST_OPENSEARCH_FIELDS,
+    str(ArticleRecommendationFields.PUBLISHED_DATE): PUBLISHED_DATE_OPENSEARCH_FIELDS,
+    str(ArticleRecommendationFields.EVALUATION_COUNT): EVALUATION_COUNT_OPENSEARCH_FIELDS
+}
+
+
+def get_source_includes(
+    embedding_vector_mapping_name: str,
+    fields: Optional[Sequence[ArticleRecommendationFieldLiteral]] = None
+) -> Sequence[str]:
+    if fields:
+        opensearch_fields_with_score_by_requested_field = {
+            **OPENSEARCH_FIELDS_BY_REQUESTED_FIELD,
+            str(ArticleRecommendationFields.SCORE): [embedding_vector_mapping_name]
+        }
+        return [
+            opensearch_field
+            for requested_field in fields
+            for opensearch_field in opensearch_fields_with_score_by_requested_field[
+                str(requested_field)
+            ]
+        ]
+    return SUPPORTED_OPENSEARCH_FIELD_NAMES + [
+        embedding_vector_mapping_name
     ]
 
 

--- a/templates/pages/article-recommendations-by-article-doi.html
+++ b/templates/pages/article-recommendations-by-article-doi.html
@@ -7,7 +7,7 @@
             <header class="page-header page-header--list">
                 <div>
                     <h1>Article Recommendations for
-                        <a href="/articles/by?article_doi={{ article_meta.article_doi }}">{{ article_meta.article_title | sanitize }}</a>
+                        <a href="/articles/by?article_doi={{ article_meta.article_doi }}">{{ article_meta.article_title_or_placeholder | sanitize }}</a>
                     </h1>
 
                     <div class="page-header__description">
@@ -15,7 +15,7 @@
                             <a href="https://www.semanticscholar.org">Semantic Scholar</a>'s
                             <a href="https://api.semanticscholar.org/api-docs/recommendations">Paper Recommendations API</a>
                             as related content to
-                            <a href="/articles/by?article_doi={{ article_meta.article_doi }}">{{ article_meta.article_title | sanitize }}</a>
+                            <a href="/articles/by?article_doi={{ article_meta.article_doi }}">{{ article_meta.article_title_or_placeholder | sanitize }}</a>
                         </span>
                         {%- if article_meta.author_name_list %}
                         <span> by

--- a/templates/pages/article-recommendations-by-sciety-list-id.atom.xml
+++ b/templates/pages/article-recommendations-by-sciety-list-id.atom.xml
@@ -12,7 +12,7 @@
 
     {%- for item in article_list_content %}
     <entry>
-        <title type="html">{{ item.article_meta.article_title }}</title>
+        <title type="html">{{ item.article_meta.article_title_or_placeholder }}</title>
         <link href="https://sciety.org/articles/activity/{{ item.article_doi }}?utm_source=sciety_labs_article_recommendations_atom_feed" />
         <published>{{ item.article_meta.published_date | date_isoformat }}T00:00:00+00:00</published>
         <updated>{{ item.article_meta.published_date | date_isoformat }}T00:00:00+00:00</updated>

--- a/templates/pages/list-by-sciety-list-id.atom.xml
+++ b/templates/pages/list-by-sciety-list-id.atom.xml
@@ -10,7 +10,7 @@
 
     {%- for item in article_list_content %}
     <entry>
-        <title type="html">{{ item.article_meta.article_title }}</title>
+        <title type="html">{{ item.article_meta.article_title_or_placeholder }}</title>
         <link href="https://sciety.org/articles/activity/{{ item.article_doi }}?utm_source=sciety_labs_atom_feed" />
         <published>{{ item.created_at_timestamp | date_isoformat }}T00:00:00+00:00</published>
         <updated>{{ item.created_at_timestamp | date_isoformat }}T00:00:00+00:00</updated>

--- a/templates/pages/search-feed.atom.xml
+++ b/templates/pages/search-feed.atom.xml
@@ -17,7 +17,7 @@
 
     {%- for item in search_results %}
     <entry>
-        <title type="html">{{ item.article_meta.article_title }}</title>
+        <title type="html">{{ item.article_meta.article_title_or_placeholder }}</title>
         <link href="https://sciety.org/articles/activity/{{ item.article_doi }}?utm_source=sciety_labs_atom_feed" />
         <published>{{ item.article_meta.published_date | date_isoformat }}T00:00:00+00:00</published>
         <updated>{{ item.article_meta.published_date | date_isoformat }}T00:00:00+00:00</updated>

--- a/tests/unit_tests/app/routers/api/article_recommendation_test.py
+++ b/tests/unit_tests/app/routers/api/article_recommendation_test.py
@@ -136,8 +136,7 @@ class TestGetRequestedFieldsForApiFieldSet:
         assert get_requested_fields_for_api_field_set({
             'externalIds'
         }) == [
-            ArticleRecommendationFields.ARTICLE_DOI,
-            ArticleRecommendationFields.ARTICLE_TITLE
+            ArticleRecommendationFields.ARTICLE_DOI
         ]
 
     def test_should_return_fields_for_title(self):
@@ -153,7 +152,6 @@ class TestGetRequestedFieldsForApiFieldSet:
             'publicationDate'
         }) == [
             ArticleRecommendationFields.ARTICLE_DOI,
-            ArticleRecommendationFields.ARTICLE_TITLE,
             ArticleRecommendationFields.PUBLISHED_DATE
         ]
 
@@ -162,7 +160,6 @@ class TestGetRequestedFieldsForApiFieldSet:
             'authors'
         }) == [
             ArticleRecommendationFields.ARTICLE_DOI,
-            ArticleRecommendationFields.ARTICLE_TITLE,
             ArticleRecommendationFields.AUTHOR_NAME_LIST
         ]
 
@@ -171,7 +168,6 @@ class TestGetRequestedFieldsForApiFieldSet:
             '_evaluationCount'
         }) == [
             ArticleRecommendationFields.ARTICLE_DOI,
-            ArticleRecommendationFields.ARTICLE_TITLE,
             ArticleRecommendationFields.EVALUATION_COUNT
         ]
 
@@ -180,7 +176,6 @@ class TestGetRequestedFieldsForApiFieldSet:
             '_score'
         }) == [
             ArticleRecommendationFields.ARTICLE_DOI,
-            ArticleRecommendationFields.ARTICLE_TITLE,
             ArticleRecommendationFields.SCORE
         ]
 

--- a/tests/unit_tests/app/routers/api/article_recommendation_test.py
+++ b/tests/unit_tests/app/routers/api/article_recommendation_test.py
@@ -10,12 +10,14 @@ import requests
 from sciety_labs.app.routers.api.article_recommendation import (
     DEFAULT_LIKE_S2_RECOMMENDATION_FIELDS,
     create_api_article_recommendation_router,
+    get_requested_fields_for_api_field_set,
     get_s2_recommended_paper_response_for_article_recommendation,
     get_s2_recommended_papers_response_for_article_recommendation_list
 )
 from sciety_labs.models.article import ArticleMetaData, ArticleStats
 from sciety_labs.providers.article_recommendation import (
     ArticleRecommendation,
+    ArticleRecommendationFields,
     ArticleRecommendationList
 )
 from sciety_labs.utils.datetime import get_utcnow
@@ -129,6 +131,60 @@ class TestGetS2RecommendedPapersResponseForArticleRecommendationList:
         ]}
 
 
+class TestGetRequestedFieldsForApiFieldSet:
+    def test_should_return_fields_for_external_reference(self):
+        assert get_requested_fields_for_api_field_set({
+            'externalIds'
+        }) == [
+            ArticleRecommendationFields.ARTICLE_DOI,
+            ArticleRecommendationFields.ARTICLE_TITLE
+        ]
+
+    def test_should_return_fields_for_title(self):
+        assert get_requested_fields_for_api_field_set({
+            'title'
+        }) == [
+            ArticleRecommendationFields.ARTICLE_DOI,
+            ArticleRecommendationFields.ARTICLE_TITLE
+        ]
+
+    def test_should_return_fields_for_publication_date(self):
+        assert get_requested_fields_for_api_field_set({
+            'publicationDate'
+        }) == [
+            ArticleRecommendationFields.ARTICLE_DOI,
+            ArticleRecommendationFields.ARTICLE_TITLE,
+            ArticleRecommendationFields.PUBLISHED_DATE
+        ]
+
+    def test_should_return_fields_for_authors(self):
+        assert get_requested_fields_for_api_field_set({
+            'authors'
+        }) == [
+            ArticleRecommendationFields.ARTICLE_DOI,
+            ArticleRecommendationFields.ARTICLE_TITLE,
+            ArticleRecommendationFields.AUTHOR_NAME_LIST
+        ]
+
+    def test_should_return_fields_for_evaluation_count(self):
+        assert get_requested_fields_for_api_field_set({
+            '_evaluationCount'
+        }) == [
+            ArticleRecommendationFields.ARTICLE_DOI,
+            ArticleRecommendationFields.ARTICLE_TITLE,
+            ArticleRecommendationFields.EVALUATION_COUNT
+        ]
+
+    def test_should_return_fields_for_score(self):
+        assert get_requested_fields_for_api_field_set({
+            '_score'
+        }) == [
+            ArticleRecommendationFields.ARTICLE_DOI,
+            ArticleRecommendationFields.ARTICLE_TITLE,
+            ArticleRecommendationFields.SCORE
+        ]
+
+
 class TestArticleRecommendationApi:
     def test_should_return_404_if_paper_id_was_missing(self, test_client: TestClient):
         response = test_client.get('/like/s2/recommendations/v1/papers/forpaper')
@@ -152,6 +208,9 @@ class TestArticleRecommendationApi:
             article_doi=DOI_1,
             max_recommendations=None,
             filter_parameters=ANY,
+            fields=get_requested_fields_for_api_field_set(
+                DEFAULT_LIKE_S2_RECOMMENDATION_FIELDS
+            ),
             headers=ANY
         )
 
@@ -193,3 +252,35 @@ class TestArticleRecommendationApi:
         )
         assert response.status_code == 404
         assert response.json() == {'error': f'Paper with id DOI:{DOI_1} not found'}
+
+    def test_should_be_able_to_select_fields(
+        self,
+        test_client: TestClient,
+        get_article_recommendation_list_for_article_doi_mock: AsyncMock
+    ):
+        test_client.get(
+            f'/like/s2/recommendations/v1/papers/forpaper/DOI:{DOI_1}',
+            params={'fields': 'title,_score'}
+        )
+        get_article_recommendation_list_for_article_doi_mock.assert_called_with(
+            article_doi=DOI_1,
+            max_recommendations=None,
+            filter_parameters=ANY,
+            fields=get_requested_fields_for_api_field_set({
+                'title', '_score'
+            }),
+            headers=ANY
+        )
+
+    def test_should_return_400_for_invalid_field(
+        self,
+        test_client: TestClient
+    ):
+        response = test_client.get(
+            f'/like/s2/recommendations/v1/papers/forpaper/DOI:{DOI_1}',
+            params={'fields': 'title,invalid-field1'}
+        )
+        assert response.status_code == 400
+        assert response.json() == {
+            'error': 'Unrecognized or unsupported fields: [invalid-field1]'
+        }

--- a/tests/unit_tests/providers/opensearch_article_recommendation_test.py
+++ b/tests/unit_tests/providers/opensearch_article_recommendation_test.py
@@ -158,16 +158,28 @@ class TestIterArticleRecommendationFromOpenSearchHits:
         assert recommendations[0].article_doi == 'doi1'
         assert recommendations[0].article_meta.article_doi == 'doi1'
 
-    def test_should_include_score_for_exactly_matching_vector(self):
+    def test_should_include_score_for_exactly_matching_nested_vector(self):
         recommendations = list(iter_article_recommendation_from_opensearch_hits([{
             '_source': {
                 **MINIMAL_DOCUMENT_DICT_1,
-                'embedding': [1, 1, 1]
+                'parent': {
+                    'embedding': [1, 1, 1]
+                }
             }
-        }], embedding_vector_mapping_name='embedding', query_vector=[1, 1, 1]))
+        }], embedding_vector_mapping_name='parent.embedding', query_vector=[1, 1, 1]))
         assert len(recommendations) == 1
         recommendation = recommendations[0]
         assert round(recommendation.score, 2) == 1.0
+
+    def test_should_not_include_score_if_nested_embedding_vector_is_not_available(self):
+        recommendations = list(iter_article_recommendation_from_opensearch_hits([{
+            '_source': {
+                **MINIMAL_DOCUMENT_DICT_1
+            }
+        }], embedding_vector_mapping_name='parent.embedding', query_vector=[1, 1, 1]))
+        assert len(recommendations) == 1
+        recommendation = recommendations[0]
+        assert recommendation.score is None
 
 
 class TestGetFromPublicationDateQueryFilter:

--- a/tests/unit_tests/providers/opensearch_article_recommendation_test.py
+++ b/tests/unit_tests/providers/opensearch_article_recommendation_test.py
@@ -1,11 +1,20 @@
 import logging
 from datetime import date
 
-from sciety_labs.providers.article_recommendation import ArticleRecommendationFilterParameters
+from sciety_labs.providers.article_recommendation import (
+    ArticleRecommendationFields,
+    ArticleRecommendationFilterParameters
+)
 from sciety_labs.providers.opensearch_article_recommendation import (
+    ARTICLE_TITLE_OPENSEARCH_FIELDS,
+    AUTHOR_LIST_OPENSEARCH_FIELDS,
+    EVALUATION_COUNT_OPENSEARCH_FIELDS,
+    PUBLISHED_DATE_OPENSEARCH_FIELDS,
+    SUPPORTED_OPENSEARCH_FIELD_NAMES,
     get_article_meta_from_document,
     get_article_recommendation_from_document,
     get_from_publication_date_query_filter,
+    get_source_includes,
     get_vector_search_query,
     iter_article_recommendation_from_opensearch_hits
 )
@@ -318,3 +327,47 @@ class TestGetVectorSearchQuery:
                 }
             }
         }
+
+
+class TestGetSourceIncludes:
+    def test_should_return_all_supported_fields_if_no_fields_specified(self):
+        assert get_source_includes('embedding_vector_1') == (
+            SUPPORTED_OPENSEARCH_FIELD_NAMES
+            + ['embedding_vector_1']
+        )
+
+    def test_should_return_doi_only_if_only_doi_was_requested(self):
+        assert get_source_includes(
+            'embedding_vector_1',
+            fields=[ArticleRecommendationFields.ARTICLE_DOI]
+        ) == ['doi']
+
+    def test_should_return_title_fields_only(self):
+        assert get_source_includes(
+            'embedding_vector_1',
+            fields=[ArticleRecommendationFields.ARTICLE_TITLE]
+        ) == ARTICLE_TITLE_OPENSEARCH_FIELDS
+
+    def test_should_return_author_name_list_fields_only(self):
+        assert get_source_includes(
+            'embedding_vector_1',
+            fields=[ArticleRecommendationFields.AUTHOR_NAME_LIST]
+        ) == AUTHOR_LIST_OPENSEARCH_FIELDS
+
+    def test_should_return_published_date_fields_only(self):
+        assert get_source_includes(
+            'embedding_vector_1',
+            fields=[ArticleRecommendationFields.PUBLISHED_DATE]
+        ) == PUBLISHED_DATE_OPENSEARCH_FIELDS
+
+    def test_should_return_evaluation_count_fields_only(self):
+        assert get_source_includes(
+            'embedding_vector_1',
+            fields=[ArticleRecommendationFields.EVALUATION_COUNT]
+        ) == EVALUATION_COUNT_OPENSEARCH_FIELDS
+
+    def test_should_return_score_fields_only(self):
+        assert get_source_includes(
+            'embedding_vector_1',
+            fields=[ArticleRecommendationFields.SCORE]
+        ) == ['embedding_vector_1']


### PR DESCRIPTION
The Related Articles API supports the `fields` parameter which influences the returned fields.

Previously those fields didn't influence the fields requested from OpenSearch. This changes it and we only request the fields from OpenSearch relating to the selected fields.
As a consequence, article_meta was also made optional in `ArticleMeta`.