### PR TITLE
Include latest_evaluation_activity_timestamp in article metadata response

### DIFF
--- a/sciety_labs/app/routers/api/categorisation/providers.py
+++ b/sciety_labs/app/routers/api/categorisation/providers.py
@@ -148,6 +148,7 @@ def get_article_dict_for_opensearch_document_dict(
     assert document_dict.get('doi')
     article_meta = get_article_meta_from_document(document_dict)
     article_stats = get_article_stats_from_document(document_dict)
+    sciety_dict = document_dict.get('sciety')
     article_dict: ArticleDict = {
         'doi': document_dict['doi'],
         'title': article_meta.article_title,
@@ -155,6 +156,11 @@ def get_article_dict_for_opensearch_document_dict(
         'evaluation_count': (
             article_stats.evaluation_count
             if article_stats
+            else None
+        ),
+        'latest_evaluation_activity_timestamp': (
+            sciety_dict.get('last_event_timestamp')
+            if sciety_dict
             else None
         )
     }

--- a/sciety_labs/app/routers/api/categorisation/typing.py
+++ b/sciety_labs/app/routers/api/categorisation/typing.py
@@ -24,6 +24,7 @@ class ArticleDict(TypedDict):
     title: NotRequired[Optional[str]]
     publication_date: NotRequired[Optional[str]]
     evaluation_count: NotRequired[Optional[int]]
+    latest_evaluation_activity_timestamp: NotRequired[Optional[str]]
     categorisation: NotRequired[Sequence[CategorisationDict]]
 
 

--- a/sciety_labs/providers/opensearch/typing.py
+++ b/sciety_labs/providers/opensearch/typing.py
@@ -67,6 +67,7 @@ class DocumentEuropePmcDict(TypedDict):
 
 class DocumentScietyDict(TypedDict):
     evaluation_count: NotRequired[int]
+    last_event_timestamp: NotRequired[str]
 
 
 class DocumentDict(TypedDict):

--- a/tests/unit_tests/app/routers/api/categorisation/providers_test.py
+++ b/tests/unit_tests/app/routers/api/categorisation/providers_test.py
@@ -210,17 +210,19 @@ class TestGetArticleResponseDictForOpensearchDocumentDict:
             }
         }
 
-    def test_should_return_response_with_evaluation_count(self):
+    def test_should_return_response_with_evaluation_count_and_timestamp(self):
         article_dict = get_article_response_dict_for_opensearch_document_dict({
             'doi': DOI_1,
             'sciety': {
-                'evaluation_count': 123
+                'evaluation_count': 123,
+                'last_event_timestamp': '2001-02-03T04:05:06+00:00'
             }
         })
         assert article_dict == {
             'data': {
                 'doi': DOI_1,
-                'evaluation_count': 123
+                'evaluation_count': 123,
+                'latest_evaluation_activity_timestamp': '2001-02-03T04:05:06+00:00'
             }
         }
 


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/881