### PR TITLE
Revise article evaluation filter to `filter[evaluated_only]`

### DIFF
--- a/sciety_labs/app/routers/api/classification/providers.py
+++ b/sciety_labs/app/routers/api/classification/providers.py
@@ -67,8 +67,11 @@ def get_classification_list_opensearch_query_dict(
     filter_dicts: List[dict] = [
         IS_BIORXIV_MEDRXIV_DOI_PREFIX_OPENSEARCH_FILTER_DICT
     ]
-    if filter_parameters.has_evaluations:
-        filter_dicts.append(IS_EVALUATED_OPENSEARCH_FILTER_DICT)
+    if filter_parameters.has_evaluations is not None:
+        if filter_parameters.has_evaluations:
+            filter_dicts.append(IS_EVALUATED_OPENSEARCH_FILTER_DICT)
+        else:
+            filter_dicts.append({'bool': {'must_not': [IS_EVALUATED_OPENSEARCH_FILTER_DICT]}})
     return {
         'query': {
             'bool': {

--- a/sciety_labs/app/routers/api/classification/providers.py
+++ b/sciety_labs/app/routers/api/classification/providers.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Mapping, Optional, Set, cast
+from typing import List, Mapping, Optional, Sequence, Set, cast
 
 import opensearchpy
 
@@ -12,7 +12,7 @@ from sciety_labs.app.routers.api.classification.typing import (
     CategorisationDict,
     CategorisationResponseDict
 )
-from sciety_labs.models.article import KnownDoiPrefix
+from sciety_labs.models.article import InternalArticleFieldNames, KnownDoiPrefix
 from sciety_labs.providers.opensearch.typing import (
     DocumentDict,
     OpenSearchSearchResultDict
@@ -39,6 +39,18 @@ IS_BIORXIV_MEDRXIV_DOI_PREFIX_OPENSEARCH_FILTER_DICT = {
     'prefix': {
         'doi': KnownDoiPrefix.BIORXIV_MEDRXIV
     }
+}
+
+
+INTERNAL_ARTICLE_FIELDS_BY_API_FIELD_NAME: Mapping[str, Sequence[str]] = {
+    'doi': [InternalArticleFieldNames.ARTICLE_DOI],
+    'title': [InternalArticleFieldNames.ARTICLE_TITLE],
+    'publication_date': [InternalArticleFieldNames.PUBLISHED_DATE],
+    'evaluation_count': [InternalArticleFieldNames.EVALUATION_COUNT],
+    'is_evaluated': [InternalArticleFieldNames.EVALUATION_COUNT],
+    'latest_evaluation_activity_timestamp': [
+        InternalArticleFieldNames.LATEST_EVALUATION_ACTIVITY_TIMESTAMP
+    ]
 }
 
 

--- a/sciety_labs/app/routers/api/classification/providers.py
+++ b/sciety_labs/app/routers/api/classification/providers.py
@@ -30,6 +30,7 @@ from sciety_labs.providers.opensearch.utils import (
 )
 from sciety_labs.utils.datetime import get_date_as_isoformat
 from sciety_labs.utils.json import get_recursively_filtered_dict_without_null_values
+from sciety_labs.utils.mapping import get_flat_mapped_values_or_all_values_for_mapping
 
 
 LOGGER = logging.getLogger(__name__)
@@ -309,15 +310,18 @@ class AsyncOpenSearchClassificationProvider:
         sort_parameters: OpenSearchSortParameters,
         pagination_parameters: OpenSearchPaginationParameters,
         article_fields_set: Optional[Set[str]] = None,
-        api_article_fields_set: Optional[Set[str]] = None,
         headers: Optional[Mapping[str, str]] = None
     ) -> ArticleSearchResponseDict:
         LOGGER.info('filter_parameters: %r', filter_parameters)
         LOGGER.info('pagination_parameters: %r', pagination_parameters)
         LOGGER.info('article_fields_set: %r', article_fields_set)
+        internal_article_fields_set = set(get_flat_mapped_values_or_all_values_for_mapping(
+            INTERNAL_ARTICLE_FIELDS_BY_API_FIELD_NAME,
+            article_fields_set
+        ))
         opensearch_fields = get_source_includes_for_mapping(
             OPENSEARCH_FIELDS_BY_REQUESTED_FIELD,
-            fields=article_fields_set
+            fields=internal_article_fields_set
         )
         LOGGER.info('opensearch_fields: %r', opensearch_fields)
         opensearch_search_result_dict = await self.async_opensearch_client.search(
@@ -333,5 +337,5 @@ class AsyncOpenSearchClassificationProvider:
         )
         return get_article_search_response_dict_for_opensearch_search_response_dict(
             opensearch_search_result_dict,
-            article_fields_set=api_article_fields_set
+            article_fields_set=article_fields_set
         )

--- a/sciety_labs/app/routers/api/classification/providers.py
+++ b/sciety_labs/app/routers/api/classification/providers.py
@@ -18,7 +18,6 @@ from sciety_labs.providers.opensearch.typing import (
     OpenSearchSearchResultDict
 )
 from sciety_labs.providers.opensearch.utils import (
-    IS_EVALUATED_OPENSEARCH_FILTER_DICT,
     OPENSEARCH_FIELDS_BY_REQUESTED_FIELD,
     OpenSearchFilterParameters,
     OpenSearchPaginationParameters,
@@ -26,6 +25,7 @@ from sciety_labs.providers.opensearch.utils import (
     OpenSearchSortParameters,
     get_article_meta_from_document,
     get_article_stats_from_document,
+    get_opensearch_filter_dicts_for_filter_parameters,
     get_source_includes_for_mapping
 )
 from sciety_labs.utils.datetime import get_date_as_isoformat
@@ -67,11 +67,9 @@ def get_classification_list_opensearch_query_dict(
     filter_dicts: List[dict] = [
         IS_BIORXIV_MEDRXIV_DOI_PREFIX_OPENSEARCH_FILTER_DICT
     ]
-    if filter_parameters.has_evaluations is not None:
-        if filter_parameters.has_evaluations:
-            filter_dicts.append(IS_EVALUATED_OPENSEARCH_FILTER_DICT)
-        else:
-            filter_dicts.append({'bool': {'must_not': [IS_EVALUATED_OPENSEARCH_FILTER_DICT]}})
+    filter_dicts.extend(get_opensearch_filter_dicts_for_filter_parameters(
+        filter_parameters=filter_parameters
+    ))
     return {
         'query': {
             'bool': {
@@ -110,11 +108,9 @@ def get_article_search_by_category_opensearch_query_dict(
         IS_BIORXIV_MEDRXIV_DOI_PREFIX_OPENSEARCH_FILTER_DICT,
         get_category_as_crossref_group_title_opensearch_filter_dict(category)
     ]
-    if filter_parameters.has_evaluations is not None:
-        if filter_parameters.has_evaluations:
-            filter_dicts.append(IS_EVALUATED_OPENSEARCH_FILTER_DICT)
-        else:
-            filter_dicts.append({'bool': {'must_not': [IS_EVALUATED_OPENSEARCH_FILTER_DICT]}})
+    filter_dicts.extend(get_opensearch_filter_dicts_for_filter_parameters(
+        filter_parameters=filter_parameters
+    ))
     query_dict: dict = {
         'query': {
             'bool': {

--- a/sciety_labs/app/routers/api/classification/providers.py
+++ b/sciety_labs/app/routers/api/classification/providers.py
@@ -249,9 +249,9 @@ LATEST_EVALUATION_TIMESTAMP_DESC_OPENSEARCH_SORT_FIELD = OpenSearchSortField(
 
 
 def get_default_article_search_sort_parameters(
-    has_evaluations: Optional[bool]
+    evaluated_only: bool
 ) -> OpenSearchSortParameters:
-    if has_evaluations:
+    if evaluated_only:
         return OpenSearchSortParameters(
             sort_fields=[LATEST_EVALUATION_TIMESTAMP_DESC_OPENSEARCH_SORT_FIELD]
         )

--- a/sciety_labs/app/routers/api/classification/providers.py
+++ b/sciety_labs/app/routers/api/classification/providers.py
@@ -67,7 +67,7 @@ def get_classification_list_opensearch_query_dict(
     filter_dicts: List[dict] = [
         IS_BIORXIV_MEDRXIV_DOI_PREFIX_OPENSEARCH_FILTER_DICT
     ]
-    if filter_parameters.evaluated_only:
+    if filter_parameters.has_evaluations:
         filter_dicts.append(IS_EVALUATED_OPENSEARCH_FILTER_DICT)
     return {
         'query': {
@@ -107,8 +107,11 @@ def get_article_search_by_category_opensearch_query_dict(
         IS_BIORXIV_MEDRXIV_DOI_PREFIX_OPENSEARCH_FILTER_DICT,
         get_category_as_crossref_group_title_opensearch_filter_dict(category)
     ]
-    if filter_parameters.evaluated_only:
-        filter_dicts.append(IS_EVALUATED_OPENSEARCH_FILTER_DICT)
+    if filter_parameters.has_evaluations is not None:
+        if filter_parameters.has_evaluations:
+            filter_dicts.append(IS_EVALUATED_OPENSEARCH_FILTER_DICT)
+        else:
+            filter_dicts.append({'bool': {'must_not': [IS_EVALUATED_OPENSEARCH_FILTER_DICT]}})
     query_dict: dict = {
         'query': {
             'bool': {
@@ -247,9 +250,9 @@ LATEST_EVALUATION_TIMESTAMP_DESC_OPENSEARCH_SORT_FIELD = OpenSearchSortField(
 
 
 def get_default_article_search_sort_parameters(
-    evaluated_only: bool
+    has_evaluations: Optional[bool]
 ) -> OpenSearchSortParameters:
-    if evaluated_only:
+    if has_evaluations:
         return OpenSearchSortParameters(
             sort_fields=[LATEST_EVALUATION_TIMESTAMP_DESC_OPENSEARCH_SORT_FIELD]
         )

--- a/sciety_labs/app/routers/api/classification/providers.py
+++ b/sciety_labs/app/routers/api/classification/providers.py
@@ -164,6 +164,11 @@ def get_article_dict_for_opensearch_document_dict(
     article_meta = get_article_meta_from_document(document_dict)
     article_stats = get_article_stats_from_document(document_dict)
     sciety_dict = document_dict.get('sciety')
+    evaluation_count = (
+        article_stats.evaluation_count
+        if article_stats
+        else None
+    )
     article_dict: ArticleDict = {
         'type': 'article',
         'id': document_dict['doi'],
@@ -171,9 +176,10 @@ def get_article_dict_for_opensearch_document_dict(
             'doi': document_dict['doi'],
             'title': article_meta.article_title,
             'publication_date': get_date_as_isoformat(article_meta.published_date),
-            'evaluation_count': (
-                article_stats.evaluation_count
-                if article_stats
+            'evaluation_count': evaluation_count,
+            'is_evaluated': (
+                bool(evaluation_count)
+                if evaluation_count is not None
                 else None
             ),
             'latest_evaluation_activity_timestamp': (

--- a/sciety_labs/app/routers/api/classification/providers.py
+++ b/sciety_labs/app/routers/api/classification/providers.py
@@ -48,7 +48,7 @@ INTERNAL_ARTICLE_FIELDS_BY_API_FIELD_NAME: Mapping[str, Sequence[str]] = {
     'title': [InternalArticleFieldNames.ARTICLE_TITLE],
     'publication_date': [InternalArticleFieldNames.PUBLISHED_DATE],
     'evaluation_count': [InternalArticleFieldNames.EVALUATION_COUNT],
-    'is_evaluated': [InternalArticleFieldNames.EVALUATION_COUNT],
+    'has_evaluations': [InternalArticleFieldNames.EVALUATION_COUNT],
     'latest_evaluation_activity_timestamp': [
         InternalArticleFieldNames.LATEST_EVALUATION_ACTIVITY_TIMESTAMP
     ]
@@ -189,7 +189,7 @@ def get_article_dict_for_opensearch_document_dict(
         'title': article_meta.article_title,
         'publication_date': get_date_as_isoformat(article_meta.published_date),
         'evaluation_count': evaluation_count,
-        'is_evaluated': (
+        'has_evaluations': (
             bool(evaluation_count)
             if evaluation_count is not None
             else None

--- a/sciety_labs/app/routers/api/classification/router.py
+++ b/sciety_labs/app/routers/api/classification/router.py
@@ -139,6 +139,7 @@ INTERNAL_ARTICLE_FIELDS_BY_API_FIELD_NAME: Mapping[str, Sequence[str]] = {
     'title': [InternalArticleFieldNames.ARTICLE_TITLE],
     'publication_date': [InternalArticleFieldNames.PUBLISHED_DATE],
     'evaluation_count': [InternalArticleFieldNames.EVALUATION_COUNT],
+    'is_evaluated': [InternalArticleFieldNames.EVALUATION_COUNT],
     'latest_evaluation_activity_timestamp': [
         InternalArticleFieldNames.LATEST_EVALUATION_ACTIVITY_TIMESTAMP
     ]
@@ -150,6 +151,7 @@ ALL_ARTICLE_FIELDS = [
     'title',
     'publication_date',
     'evaluation_count',
+    'is_evaluated',
     'latest_evaluation_activity_timestamp'
 ]
 
@@ -318,6 +320,7 @@ def create_api_classification_router(
                     page_number=page_number
                 ),
                 article_fields_set=internal_article_fields_set,
+                api_article_fields_set=api_article_fields_set,
                 headers=get_cache_control_headers_for_request(request)
             )
         )

--- a/sciety_labs/app/routers/api/classification/router.py
+++ b/sciety_labs/app/routers/api/classification/router.py
@@ -236,7 +236,7 @@ def create_api_classification_router(
     )
     async def classifications_list(
         request: fastapi.Request,
-        evaluated_only: bool = fastapi.Query(alias='filter[is_evaluated]', default=False)
+        evaluated_only: bool = fastapi.Query(alias='filter[has_evaluations]', default=False)
     ):
         return await (
             async_opensearch_classification_provider
@@ -273,7 +273,7 @@ def create_api_classification_router(
     async def articles_by_category(  # pylint: disable=too-many-arguments
         request: fastapi.Request,
         category: str,
-        evaluated_only: bool = fastapi.Query(alias='filter[is_evaluated]', default=False),
+        evaluated_only: bool = fastapi.Query(alias='filter[has_evaluations]', default=False),
         page_size: int = fastapi.Query(alias='page[size]', default=10),
         page_number: int = fastapi.Query(alias='page[number]', ge=1, default=1),
         api_article_fields_csv: str = ARTICLE_FIELDS_FASTAPI_QUERY

--- a/sciety_labs/app/routers/api/classification/router.py
+++ b/sciety_labs/app/routers/api/classification/router.py
@@ -10,7 +10,6 @@ from sciety_labs.app.routers.api.utils.jsonapi import (
 from sciety_labs.app.routers.api.utils.jsonapi_typing import JsonApiErrorsResponseDict
 from sciety_labs.app.routers.api.utils.validation import InvalidApiFieldsError, validate_api_fields
 from sciety_labs.app.routers.api.classification.providers import (
-    INTERNAL_ARTICLE_FIELDS_BY_API_FIELD_NAME,
     ArticleDoiNotFoundError,
     AsyncOpenSearchClassificationProvider,
     get_default_article_search_sort_parameters
@@ -24,7 +23,6 @@ from sciety_labs.providers.opensearch.utils import (
     OpenSearchPaginationParameters
 )
 from sciety_labs.utils.fastapi import get_cache_control_headers_for_request
-from sciety_labs.utils.mapping import get_flat_mapped_values_or_all_values_for_mapping
 
 
 LOGGER = logging.getLogger(__name__)
@@ -288,10 +286,6 @@ def create_api_classification_router(
     ):
         api_article_fields_set = set(api_article_fields_csv.split(','))
         validate_api_fields(api_article_fields_set, valid_values=ALL_ARTICLE_FIELDS)
-        internal_article_fields_set = set(get_flat_mapped_values_or_all_values_for_mapping(
-            INTERNAL_ARTICLE_FIELDS_BY_API_FIELD_NAME,
-            api_article_fields_set
-        ))
         return await (
             async_opensearch_classification_provider
             .get_article_search_response_dict_by_category(
@@ -306,8 +300,7 @@ def create_api_classification_router(
                     page_size=page_size,
                     page_number=page_number
                 ),
-                article_fields_set=internal_article_fields_set,
-                api_article_fields_set=api_article_fields_set,
+                article_fields_set=api_article_fields_set,
                 headers=get_cache_control_headers_for_request(request)
             )
         )

--- a/sciety_labs/app/routers/api/classification/router.py
+++ b/sciety_labs/app/routers/api/classification/router.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 
 import fastapi
 
@@ -237,15 +236,13 @@ def create_api_classification_router(
     )
     async def classifications_list(
         request: fastapi.Request,
-        has_evaluations: Optional[bool] = (
-            fastapi.Query(alias='filter[has_evaluations]', default=None)
-        ),
+        evaluated_only: bool = fastapi.Query(alias='filter[evaluated_only]', default=False)
     ):
         return await (
             async_opensearch_classification_provider
             .get_classification_list_response_dict(
                 filter_parameters=OpenSearchFilterParameters(
-                    has_evaluations=has_evaluations
+                    evaluated_only=evaluated_only
                 ),
                 headers=get_cache_control_headers_for_request(request)
             )
@@ -276,9 +273,7 @@ def create_api_classification_router(
     async def articles_by_category(  # pylint: disable=too-many-arguments
         request: fastapi.Request,
         category: str,
-        has_evaluations: Optional[bool] = (
-            fastapi.Query(alias='filter[has_evaluations]', default=None)
-        ),
+        evaluated_only: bool = fastapi.Query(alias='filter[evaluated_only]', default=False),
         page_size: int = fastapi.Query(alias='page[size]', default=10),
         page_number: int = fastapi.Query(alias='page[number]', ge=1, default=1),
         api_article_fields_csv: str = ARTICLE_FIELDS_FASTAPI_QUERY
@@ -290,10 +285,10 @@ def create_api_classification_router(
             .get_article_search_response_dict_by_category(
                 category=category,
                 filter_parameters=OpenSearchFilterParameters(
-                    has_evaluations=has_evaluations
+                    evaluated_only=evaluated_only
                 ),
                 sort_parameters=get_default_article_search_sort_parameters(
-                    has_evaluations=has_evaluations
+                    evaluated_only=evaluated_only
                 ),
                 pagination_parameters=OpenSearchPaginationParameters(
                     page_size=page_size,

--- a/sciety_labs/app/routers/api/classification/router.py
+++ b/sciety_labs/app/routers/api/classification/router.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Mapping, Sequence
 
 import fastapi
 
@@ -11,6 +10,7 @@ from sciety_labs.app.routers.api.utils.jsonapi import (
 from sciety_labs.app.routers.api.utils.jsonapi_typing import JsonApiErrorsResponseDict
 from sciety_labs.app.routers.api.utils.validation import InvalidApiFieldsError, validate_api_fields
 from sciety_labs.app.routers.api.classification.providers import (
+    INTERNAL_ARTICLE_FIELDS_BY_API_FIELD_NAME,
     ArticleDoiNotFoundError,
     AsyncOpenSearchClassificationProvider,
     get_default_article_search_sort_parameters
@@ -19,7 +19,6 @@ from sciety_labs.app.routers.api.classification.typing import (
     ArticleSearchResponseDict,
     CategorisationResponseDict
 )
-from sciety_labs.models.article import InternalArticleFieldNames
 from sciety_labs.providers.opensearch.utils import (
     OpenSearchFilterParameters,
     OpenSearchPaginationParameters
@@ -132,18 +131,6 @@ ARTICLES_BY_CATEGORY_API_EXAMPLE_RESPONSES: dict = {
 
 
 DEFAULT_ARTICLE_FIELDS = {'doi'}
-
-
-INTERNAL_ARTICLE_FIELDS_BY_API_FIELD_NAME: Mapping[str, Sequence[str]] = {
-    'doi': [InternalArticleFieldNames.ARTICLE_DOI],
-    'title': [InternalArticleFieldNames.ARTICLE_TITLE],
-    'publication_date': [InternalArticleFieldNames.PUBLISHED_DATE],
-    'evaluation_count': [InternalArticleFieldNames.EVALUATION_COUNT],
-    'is_evaluated': [InternalArticleFieldNames.EVALUATION_COUNT],
-    'latest_evaluation_activity_timestamp': [
-        InternalArticleFieldNames.LATEST_EVALUATION_ACTIVITY_TIMESTAMP
-    ]
-}
 
 
 ALL_ARTICLE_FIELDS = [

--- a/sciety_labs/app/routers/api/classification/router.py
+++ b/sciety_labs/app/routers/api/classification/router.py
@@ -237,13 +237,15 @@ def create_api_classification_router(
     )
     async def classifications_list(
         request: fastapi.Request,
-        evaluated_only: bool = fastapi.Query(alias='filter[has_evaluations]', default=False)
+        has_evaluations: Optional[bool] = (
+            fastapi.Query(alias='filter[has_evaluations]', default=None)
+        ),
     ):
         return await (
             async_opensearch_classification_provider
             .get_classification_list_response_dict(
                 filter_parameters=OpenSearchFilterParameters(
-                    has_evaluations=evaluated_only
+                    has_evaluations=has_evaluations
                 ),
                 headers=get_cache_control_headers_for_request(request)
             )
@@ -274,7 +276,7 @@ def create_api_classification_router(
     async def articles_by_category(  # pylint: disable=too-many-arguments
         request: fastapi.Request,
         category: str,
-        evaluated_only: Optional[bool] = (
+        has_evaluations: Optional[bool] = (
             fastapi.Query(alias='filter[has_evaluations]', default=None)
         ),
         page_size: int = fastapi.Query(alias='page[size]', default=10),
@@ -288,10 +290,10 @@ def create_api_classification_router(
             .get_article_search_response_dict_by_category(
                 category=category,
                 filter_parameters=OpenSearchFilterParameters(
-                    has_evaluations=evaluated_only
+                    has_evaluations=has_evaluations
                 ),
                 sort_parameters=get_default_article_search_sort_parameters(
-                    has_evaluations=evaluated_only
+                    has_evaluations=has_evaluations
                 ),
                 pagination_parameters=OpenSearchPaginationParameters(
                     page_size=page_size,

--- a/sciety_labs/app/routers/api/classification/router.py
+++ b/sciety_labs/app/routers/api/classification/router.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 import fastapi
 
@@ -242,7 +243,7 @@ def create_api_classification_router(
             async_opensearch_classification_provider
             .get_classification_list_response_dict(
                 filter_parameters=OpenSearchFilterParameters(
-                    evaluated_only=evaluated_only
+                    has_evaluations=evaluated_only
                 ),
                 headers=get_cache_control_headers_for_request(request)
             )
@@ -273,7 +274,7 @@ def create_api_classification_router(
     async def articles_by_category(  # pylint: disable=too-many-arguments
         request: fastapi.Request,
         category: str,
-        evaluated_only: bool = fastapi.Query(alias='filter[has_evaluations]', default=False),
+        evaluated_only: Optional[bool] = fastapi.Query(alias='filter[has_evaluations]', default=None),
         page_size: int = fastapi.Query(alias='page[size]', default=10),
         page_number: int = fastapi.Query(alias='page[number]', ge=1, default=1),
         api_article_fields_csv: str = ARTICLE_FIELDS_FASTAPI_QUERY
@@ -285,10 +286,10 @@ def create_api_classification_router(
             .get_article_search_response_dict_by_category(
                 category=category,
                 filter_parameters=OpenSearchFilterParameters(
-                    evaluated_only=evaluated_only
+                    has_evaluations=evaluated_only
                 ),
                 sort_parameters=get_default_article_search_sort_parameters(
-                    evaluated_only=evaluated_only
+                    has_evaluations=evaluated_only
                 ),
                 pagination_parameters=OpenSearchPaginationParameters(
                     page_size=page_size,

--- a/sciety_labs/app/routers/api/classification/router.py
+++ b/sciety_labs/app/routers/api/classification/router.py
@@ -274,7 +274,9 @@ def create_api_classification_router(
     async def articles_by_category(  # pylint: disable=too-many-arguments
         request: fastapi.Request,
         category: str,
-        evaluated_only: Optional[bool] = fastapi.Query(alias='filter[has_evaluations]', default=None),
+        evaluated_only: Optional[bool] = (
+            fastapi.Query(alias='filter[has_evaluations]', default=None)
+        ),
         page_size: int = fastapi.Query(alias='page[size]', default=10),
         page_number: int = fastapi.Query(alias='page[number]', ge=1, default=1),
         api_article_fields_csv: str = ARTICLE_FIELDS_FASTAPI_QUERY

--- a/sciety_labs/app/routers/api/classification/router.py
+++ b/sciety_labs/app/routers/api/classification/router.py
@@ -279,7 +279,7 @@ def create_api_classification_router(
     async def articles_by_category(  # pylint: disable=too-many-arguments
         request: fastapi.Request,
         category: str,
-        evaluated_only: bool = False,
+        evaluated_only: bool = fastapi.Query(alias='filter[is_evaluated]', default=False),
         page_size: int = fastapi.Query(alias='page[size]', default=10),
         page_number: int = fastapi.Query(alias='page[number]', ge=1, default=1),
         api_article_fields_csv: str = ARTICLE_FIELDS_FASTAPI_QUERY

--- a/sciety_labs/app/routers/api/classification/router.py
+++ b/sciety_labs/app/routers/api/classification/router.py
@@ -236,7 +236,7 @@ def create_api_classification_router(
     )
     async def classifications_list(
         request: fastapi.Request,
-        evaluated_only: bool = False
+        evaluated_only: bool = fastapi.Query(alias='filter[is_evaluated]', default=False)
     ):
         return await (
             async_opensearch_classification_provider

--- a/sciety_labs/app/routers/api/classification/router.py
+++ b/sciety_labs/app/routers/api/classification/router.py
@@ -10,6 +10,7 @@ from sciety_labs.app.routers.api.utils.jsonapi import (
 from sciety_labs.app.routers.api.utils.jsonapi_typing import JsonApiErrorsResponseDict
 from sciety_labs.app.routers.api.utils.validation import InvalidApiFieldsError, validate_api_fields
 from sciety_labs.app.routers.api.classification.providers import (
+    INTERNAL_ARTICLE_FIELDS_BY_API_FIELD_NAME,
     ArticleDoiNotFoundError,
     AsyncOpenSearchClassificationProvider,
     get_default_article_search_sort_parameters
@@ -131,14 +132,7 @@ ARTICLES_BY_CATEGORY_API_EXAMPLE_RESPONSES: dict = {
 DEFAULT_ARTICLE_FIELDS = {'doi'}
 
 
-ALL_ARTICLE_FIELDS = [
-    'doi',
-    'title',
-    'publication_date',
-    'evaluation_count',
-    'is_evaluated',
-    'latest_evaluation_activity_timestamp'
-]
+ALL_ARTICLE_FIELDS = list(INTERNAL_ARTICLE_FIELDS_BY_API_FIELD_NAME.keys())
 
 ALL_ARTICLE_FIELDS_CSV = ','.join(ALL_ARTICLE_FIELDS)
 

--- a/sciety_labs/app/routers/api/classification/typing.py
+++ b/sciety_labs/app/routers/api/classification/typing.py
@@ -18,6 +18,7 @@ class ArticleAttributesDict(TypedDict):
     title: NotRequired[Optional[str]]
     publication_date: NotRequired[Optional[str]]
     evaluation_count: NotRequired[Optional[int]]
+    is_evaluated: NotRequired[Optional[bool]]
     latest_evaluation_activity_timestamp: NotRequired[Optional[str]]
     classifications: NotRequired[Sequence[CategorisationDict]]
 

--- a/sciety_labs/app/routers/api/classification/typing.py
+++ b/sciety_labs/app/routers/api/classification/typing.py
@@ -18,7 +18,7 @@ class ArticleAttributesDict(TypedDict):
     title: NotRequired[Optional[str]]
     publication_date: NotRequired[Optional[str]]
     evaluation_count: NotRequired[Optional[int]]
-    is_evaluated: NotRequired[Optional[bool]]
+    has_evaluations: NotRequired[Optional[bool]]
     latest_evaluation_activity_timestamp: NotRequired[Optional[str]]
     classifications: NotRequired[Sequence[CategorisationDict]]
 

--- a/sciety_labs/providers/opensearch/utils.py
+++ b/sciety_labs/providers/opensearch/utils.py
@@ -48,7 +48,7 @@ DEFAULT_PAGE_SIZE = 10
 
 @dataclasses.dataclass(frozen=True)
 class OpenSearchFilterParameters:
-    evaluated_only: bool = False
+    has_evaluations: Optional[bool] = None
 
 
 @dataclasses.dataclass(frozen=True)

--- a/sciety_labs/providers/opensearch/utils.py
+++ b/sciety_labs/providers/opensearch/utils.py
@@ -48,7 +48,7 @@ DEFAULT_PAGE_SIZE = 10
 
 @dataclasses.dataclass(frozen=True)
 class OpenSearchFilterParameters:
-    has_evaluations: Optional[bool] = None
+    evaluated_only: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -91,11 +91,8 @@ def get_opensearch_filter_dicts_for_filter_parameters(
     filter_parameters: OpenSearchFilterParameters
 ) -> Sequence[dict]:
     filter_dicts: List[dict] = []
-    if filter_parameters.has_evaluations is not None:
-        if filter_parameters.has_evaluations:
-            filter_dicts.append(IS_EVALUATED_OPENSEARCH_FILTER_DICT)
-        else:
-            filter_dicts.append({'bool': {'must_not': [IS_EVALUATED_OPENSEARCH_FILTER_DICT]}})
+    if filter_parameters.evaluated_only:
+        filter_dicts.append(IS_EVALUATED_OPENSEARCH_FILTER_DICT)
     return filter_dicts
 
 

--- a/sciety_labs/providers/opensearch/utils.py
+++ b/sciety_labs/providers/opensearch/utils.py
@@ -1,7 +1,7 @@
 import dataclasses
 import logging
 from datetime import date, timedelta
-from typing import Any, Iterable, Literal, Mapping, Optional, Sequence, cast
+from typing import Any, Iterable, List, Literal, Mapping, Optional, Sequence, cast
 
 
 import numpy.typing as npt
@@ -85,6 +85,18 @@ class OpenSearchPaginationParameters:
 
     def get_offset(self) -> int:
         return self.page_size * (self.page_number - 1)
+
+
+def get_opensearch_filter_dicts_for_filter_parameters(
+    filter_parameters: OpenSearchFilterParameters
+) -> Sequence[dict]:
+    filter_dicts: List[dict] = []
+    if filter_parameters.has_evaluations is not None:
+        if filter_parameters.has_evaluations:
+            filter_dicts.append(IS_EVALUATED_OPENSEARCH_FILTER_DICT)
+        else:
+            filter_dicts.append({'bool': {'must_not': [IS_EVALUATED_OPENSEARCH_FILTER_DICT]}})
+    return filter_dicts
 
 
 def get_author_names_for_document_s2_authors(

--- a/tests/unit_tests/app/routers/api/classification/providers_test.py
+++ b/tests/unit_tests/app/routers/api/classification/providers_test.py
@@ -67,28 +67,19 @@ class TestArticleDoiNotFoundError:
 class TestGetClassificationListOpenSearchQueryDict:
     def test_should_include_biorxiv_medrxiv_filter(self):
         query_dict = get_classification_list_opensearch_query_dict(
-            filter_parameters=OpenSearchFilterParameters(has_evaluations=None)
+            filter_parameters=OpenSearchFilterParameters(evaluated_only=False)
         )
         assert query_dict['query']['bool']['filter'] == [
             IS_BIORXIV_MEDRXIV_DOI_PREFIX_OPENSEARCH_FILTER_DICT
         ]
 
-    def test_should_include_has_evaluations_filter(self):
+    def test_should_include_evaluated_only_filter(self):
         query_dict = get_classification_list_opensearch_query_dict(
-            filter_parameters=OpenSearchFilterParameters(has_evaluations=True)
+            filter_parameters=OpenSearchFilterParameters(evaluated_only=True)
         )
         assert query_dict['query']['bool']['filter'] == [
             IS_BIORXIV_MEDRXIV_DOI_PREFIX_OPENSEARCH_FILTER_DICT,
             IS_EVALUATED_OPENSEARCH_FILTER_DICT
-        ]
-
-    def test_should_include_negative_has_evaluations_filter(self):
-        query_dict = get_classification_list_opensearch_query_dict(
-            filter_parameters=OpenSearchFilterParameters(has_evaluations=False)
-        )
-        assert query_dict['query']['bool']['filter'] == [
-            IS_BIORXIV_MEDRXIV_DOI_PREFIX_OPENSEARCH_FILTER_DICT,
-            {'bool': {'must_not': [IS_EVALUATED_OPENSEARCH_FILTER_DICT]}}
         ]
 
 
@@ -96,7 +87,7 @@ class TestGetArticleSearchByCategoryOpenSearchQueryDict:
     def test_should_include_category_filter(self):
         query_dict = get_article_search_by_category_opensearch_query_dict(
             category='Category 1',
-            filter_parameters=OpenSearchFilterParameters(has_evaluations=None),
+            filter_parameters=OpenSearchFilterParameters(evaluated_only=False),
             sort_parameters=OpenSearchSortParameters(),
             pagination_parameters=OpenSearchPaginationParameters()
         )
@@ -112,7 +103,7 @@ class TestGetArticleSearchByCategoryOpenSearchQueryDict:
     def test_should_include_category_and_has_evaluations_filter(self):
         query_dict = get_article_search_by_category_opensearch_query_dict(
             category='Category 1',
-            filter_parameters=OpenSearchFilterParameters(has_evaluations=True),
+            filter_parameters=OpenSearchFilterParameters(evaluated_only=True),
             sort_parameters=OpenSearchSortParameters(),
             pagination_parameters=OpenSearchPaginationParameters()
         )
@@ -122,23 +113,10 @@ class TestGetArticleSearchByCategoryOpenSearchQueryDict:
             IS_EVALUATED_OPENSEARCH_FILTER_DICT
         ]
 
-    def test_should_include_category_and_negative_has_evaluations_filter(self):
-        query_dict = get_article_search_by_category_opensearch_query_dict(
-            category='Category 1',
-            filter_parameters=OpenSearchFilterParameters(has_evaluations=False),
-            sort_parameters=OpenSearchSortParameters(),
-            pagination_parameters=OpenSearchPaginationParameters()
-        )
-        assert query_dict['query']['bool']['filter'] == [
-            IS_BIORXIV_MEDRXIV_DOI_PREFIX_OPENSEARCH_FILTER_DICT,
-            get_category_as_crossref_group_title_opensearch_filter_dict('Category 1'),
-            {'bool': {'must_not': [IS_EVALUATED_OPENSEARCH_FILTER_DICT]}}
-        ]
-
     def test_should_be_able_to_sort_by_latest_evaluation_activity(self):
         query_dict = get_article_search_by_category_opensearch_query_dict(
             category='Category 1',
-            filter_parameters=OpenSearchFilterParameters(has_evaluations=True),
+            filter_parameters=OpenSearchFilterParameters(evaluated_only=True),
             sort_parameters=OpenSearchSortParameters(sort_fields=[OpenSearchSortField(
                 field_name='sciety.last_event_timestamp',
                 sort_order='desc'
@@ -156,7 +134,7 @@ class TestGetArticleSearchByCategoryOpenSearchQueryDict:
     def test_should_use_page_size_and_page_number(self):
         query_dict = get_article_search_by_category_opensearch_query_dict(
             category='Category 1',
-            filter_parameters=OpenSearchFilterParameters(has_evaluations=True),
+            filter_parameters=OpenSearchFilterParameters(evaluated_only=True),
             sort_parameters=OpenSearchSortParameters(sort_fields=[]),
             pagination_parameters=OpenSearchPaginationParameters(
                 page_size=100,
@@ -369,14 +347,14 @@ class TestGetArticleSearchResponseDictForOpenSearchSearchResponseDict:
 class TestGetDefaultArticleSearchSortParameters:
     def test_should_not_sort_by_if_not_evaluation_only(self):
         sort_parameters = get_default_article_search_sort_parameters(
-            has_evaluations=False
+            evaluated_only=False
         )
         assert not sort_parameters.sort_fields
         assert not sort_parameters
 
     def test_should_sort_by_evaluation_activity_descending_if_evaluation_only(self):
         sort_parameters = get_default_article_search_sort_parameters(
-            has_evaluations=True
+            evaluated_only=True
         )
         assert sort_parameters == OpenSearchSortParameters(sort_fields=[
             LATEST_EVALUATION_TIMESTAMP_DESC_OPENSEARCH_SORT_FIELD

--- a/tests/unit_tests/app/routers/api/classification/providers_test.py
+++ b/tests/unit_tests/app/routers/api/classification/providers_test.py
@@ -270,7 +270,6 @@ class TestGetArticleDictForOpenSearchDocumentDict:
             'doi': DOI_1,
             'sciety': {
                 'evaluation_count': 123,
-                'is_evaluated': True,
                 'last_event_timestamp': '2001-02-03T04:05:06+00:00'
             }
         })
@@ -282,6 +281,26 @@ class TestGetArticleDictForOpenSearchDocumentDict:
                 'evaluation_count': 123,
                 'is_evaluated': True,
                 'latest_evaluation_activity_timestamp': '2001-02-03T04:05:06+00:00'
+            }
+        }
+
+    def test_should_filter_attributes(self):
+        article_dict = get_article_dict_for_opensearch_document_dict(
+            {
+                'doi': DOI_1,
+                'sciety': {
+                    'evaluation_count': 123,
+                    'last_event_timestamp': '2001-02-03T04:05:06+00:00'
+                }
+            },
+            article_fields_set={'doi', 'is_evaluated'}
+        )
+        assert article_dict == {
+            'type': 'article',
+            'id': DOI_1,
+            'attributes': {
+                'doi': DOI_1,
+                'is_evaluated': True
             }
         }
 

--- a/tests/unit_tests/app/routers/api/classification/providers_test.py
+++ b/tests/unit_tests/app/routers/api/classification/providers_test.py
@@ -73,7 +73,7 @@ class TestGetClassificationListOpenSearchQueryDict:
             IS_BIORXIV_MEDRXIV_DOI_PREFIX_OPENSEARCH_FILTER_DICT
         ]
 
-    def test_should_include_is_evaluated_filter(self):
+    def test_should_include_has_evaluations_filter(self):
         query_dict = get_classification_list_opensearch_query_dict(
             filter_parameters=OpenSearchFilterParameters(evaluated_only=True)
         )
@@ -100,7 +100,7 @@ class TestGetArticleSearchByCategoryOpenSearchQueryDict:
             }
         }
 
-    def test_should_include_category_and_is_evaluated_filter(self):
+    def test_should_include_category_and_has_evaluations_filter(self):
         query_dict = get_article_search_by_category_opensearch_query_dict(
             category='Category 1',
             filter_parameters=OpenSearchFilterParameters(evaluated_only=True),
@@ -279,7 +279,7 @@ class TestGetArticleDictForOpenSearchDocumentDict:
             'attributes': {
                 'doi': DOI_1,
                 'evaluation_count': 123,
-                'is_evaluated': True,
+                'has_evaluations': True,
                 'latest_evaluation_activity_timestamp': '2001-02-03T04:05:06+00:00'
             }
         }
@@ -293,14 +293,14 @@ class TestGetArticleDictForOpenSearchDocumentDict:
                     'last_event_timestamp': '2001-02-03T04:05:06+00:00'
                 }
             },
-            article_fields_set={'doi', 'is_evaluated'}
+            article_fields_set={'doi', 'has_evaluations'}
         )
         assert article_dict == {
             'type': 'article',
             'id': DOI_1,
             'attributes': {
                 'doi': DOI_1,
-                'is_evaluated': True
+                'has_evaluations': True
             }
         }
 

--- a/tests/unit_tests/app/routers/api/classification/providers_test.py
+++ b/tests/unit_tests/app/routers/api/classification/providers_test.py
@@ -270,6 +270,7 @@ class TestGetArticleDictForOpenSearchDocumentDict:
             'doi': DOI_1,
             'sciety': {
                 'evaluation_count': 123,
+                'is_evaluated': True,
                 'last_event_timestamp': '2001-02-03T04:05:06+00:00'
             }
         })
@@ -279,6 +280,7 @@ class TestGetArticleDictForOpenSearchDocumentDict:
             'attributes': {
                 'doi': DOI_1,
                 'evaluation_count': 123,
+                'is_evaluated': True,
                 'latest_evaluation_activity_timestamp': '2001-02-03T04:05:06+00:00'
             }
         }

--- a/tests/unit_tests/app/routers/api/classification/providers_test.py
+++ b/tests/unit_tests/app/routers/api/classification/providers_test.py
@@ -67,7 +67,7 @@ class TestArticleDoiNotFoundError:
 class TestGetClassificationListOpenSearchQueryDict:
     def test_should_include_biorxiv_medrxiv_filter(self):
         query_dict = get_classification_list_opensearch_query_dict(
-            filter_parameters=OpenSearchFilterParameters(has_evaluations=False)
+            filter_parameters=OpenSearchFilterParameters(has_evaluations=None)
         )
         assert query_dict['query']['bool']['filter'] == [
             IS_BIORXIV_MEDRXIV_DOI_PREFIX_OPENSEARCH_FILTER_DICT
@@ -80,6 +80,15 @@ class TestGetClassificationListOpenSearchQueryDict:
         assert query_dict['query']['bool']['filter'] == [
             IS_BIORXIV_MEDRXIV_DOI_PREFIX_OPENSEARCH_FILTER_DICT,
             IS_EVALUATED_OPENSEARCH_FILTER_DICT
+        ]
+
+    def test_should_include_negative_has_evaluations_filter(self):
+        query_dict = get_classification_list_opensearch_query_dict(
+            filter_parameters=OpenSearchFilterParameters(has_evaluations=False)
+        )
+        assert query_dict['query']['bool']['filter'] == [
+            IS_BIORXIV_MEDRXIV_DOI_PREFIX_OPENSEARCH_FILTER_DICT,
+            {'bool': {'must_not': [IS_EVALUATED_OPENSEARCH_FILTER_DICT]}}
         ]
 
 

--- a/tests/unit_tests/app/routers/api/classification/router_test.py
+++ b/tests/unit_tests/app/routers/api/classification/router_test.py
@@ -184,7 +184,7 @@ class TestCategorisationApiRouterArticlesByCategory:
         response.raise_for_status()
         assert response.json() == ARTICLE_SEARCH_RESPONSE_DICT_1
 
-    def test_should_pass_evaluated_only_filter_to_provider(
+    def test_should_pass_evaluated_only_and_category_filter_to_provider(
         self,
         get_article_search_response_dict_by_category_mock: AsyncMock,
         test_client: TestClient
@@ -199,6 +199,7 @@ class TestCategorisationApiRouterArticlesByCategory:
         _, kwargs = get_article_search_response_dict_by_category_mock.call_args
         filter_parameters: OpenSearchFilterParameters = kwargs['filter_parameters']
         assert filter_parameters.evaluated_only
+        assert kwargs['category'] == 'Category 1'
 
     def test_should_pass_mapped_api_fields_to_provider(
         self,

--- a/tests/unit_tests/app/routers/api/classification/router_test.py
+++ b/tests/unit_tests/app/routers/api/classification/router_test.py
@@ -136,7 +136,7 @@ class TestClassificationApiRouterClassificationList:
         response.raise_for_status()
         assert response.json() == CATEGORISATION_RESPONSE_DICT_1
 
-    def test_should_pass_has_evaluations_filter_to_provider(
+    def test_should_pass_evaluated_only_filter_to_provider(
         self,
         get_classification_list_response_dict_mock: AsyncMock,
         test_client: TestClient
@@ -146,11 +146,11 @@ class TestClassificationApiRouterClassificationList:
         )
         test_client.get(
             '/classification/v1/classifications',
-            params={'filter[has_evaluations]': 'true'}
+            params={'filter[evaluated_only]': 'true'}
         )
         _, kwargs = get_classification_list_response_dict_mock.call_args
         filter_parameters: OpenSearchFilterParameters = kwargs['filter_parameters']
-        assert filter_parameters.has_evaluations
+        assert filter_parameters.evaluated_only
 
 
 class TestClassificationApiRouterClassificationListByDoi:
@@ -200,7 +200,7 @@ class TestClassificationApiRouterArticlesByCategory:
         response.raise_for_status()
         assert response.json() == ARTICLE_SEARCH_RESPONSE_DICT_1
 
-    def test_should_pass_has_evaluations_and_category_filter_to_provider(
+    def test_should_pass_evaluated_only_and_category_filter_to_provider(
         self,
         get_article_search_response_dict_by_category_mock: AsyncMock,
         test_client: TestClient
@@ -210,11 +210,11 @@ class TestClassificationApiRouterArticlesByCategory:
         )
         test_client.get(
             '/classification/v1/articles/by/category',
-            params={'category': 'Category 1', 'filter[has_evaluations]': 'true'}
+            params={'category': 'Category 1', 'filter[evaluated_only]': 'true'}
         )
         _, kwargs = get_article_search_response_dict_by_category_mock.call_args
         filter_parameters: OpenSearchFilterParameters = kwargs['filter_parameters']
-        assert filter_parameters.has_evaluations
+        assert filter_parameters.evaluated_only
         assert kwargs['category'] == 'Category 1'
 
     def test_should_pass_api_fields_to_provider(

--- a/tests/unit_tests/app/routers/api/classification/router_test.py
+++ b/tests/unit_tests/app/routers/api/classification/router_test.py
@@ -193,7 +193,7 @@ class TestClassificationApiRouterArticlesByCategory:
         )
         test_client.get(
             '/classification/v1/articles/by/category',
-            params={'category': 'Category 1', 'evaluated_only': 'true'}
+            params={'category': 'Category 1', 'filter[is_evaluated]': 'true'}
         )
         _, kwargs = get_article_search_response_dict_by_category_mock.call_args
         filter_parameters: OpenSearchFilterParameters = kwargs['filter_parameters']

--- a/tests/unit_tests/app/routers/api/classification/router_test.py
+++ b/tests/unit_tests/app/routers/api/classification/router_test.py
@@ -150,7 +150,7 @@ class TestClassificationApiRouterClassificationList:
         )
         _, kwargs = get_classification_list_response_dict_mock.call_args
         filter_parameters: OpenSearchFilterParameters = kwargs['filter_parameters']
-        assert filter_parameters.evaluated_only
+        assert filter_parameters.has_evaluations
 
 
 class TestClassificationApiRouterClassificationListByDoi:
@@ -214,7 +214,7 @@ class TestClassificationApiRouterArticlesByCategory:
         )
         _, kwargs = get_article_search_response_dict_by_category_mock.call_args
         filter_parameters: OpenSearchFilterParameters = kwargs['filter_parameters']
-        assert filter_parameters.evaluated_only
+        assert filter_parameters.has_evaluations
         assert kwargs['category'] == 'Category 1'
 
     def test_should_pass_api_fields_to_provider(

--- a/tests/unit_tests/app/routers/api/classification/router_test.py
+++ b/tests/unit_tests/app/routers/api/classification/router_test.py
@@ -123,7 +123,7 @@ class TestGetNotFoundErrorJsonResponseDict:
         }
 
 
-class TestCategorisationApiRouter:
+class TestClassificationApiRouter:
     def test_should_provide_classification_list_response(
         self,
         get_classification_list_response_dict_mock: AsyncMock,
@@ -167,7 +167,7 @@ class TestCategorisationApiRouter:
         assert response.json() == get_not_found_error_json_response_dict(exception)
 
 
-class TestCategorisationApiRouterArticlesByCategory:
+class TestClassificationApiRouterArticlesByCategory:
     def test_should_return_response_from_provider(
         self,
         get_article_search_response_dict_by_category_mock: AsyncMock,

--- a/tests/unit_tests/app/routers/api/classification/router_test.py
+++ b/tests/unit_tests/app/routers/api/classification/router_test.py
@@ -22,7 +22,6 @@ from sciety_labs.app.routers.api.classification.typing import (
     CategorisationResponseDict
 )
 from sciety_labs.app.routers.api.utils.validation import InvalidApiFieldsError
-from sciety_labs.models.article import InternalArticleFieldNames
 from sciety_labs.providers.opensearch.utils import OpenSearchFilterParameters
 
 
@@ -201,7 +200,7 @@ class TestCategorisationApiRouterArticlesByCategory:
         assert filter_parameters.evaluated_only
         assert kwargs['category'] == 'Category 1'
 
-    def test_should_pass_mapped_api_fields_to_provider(
+    def test_should_pass_api_fields_to_provider(
         self,
         get_article_search_response_dict_by_category_mock: AsyncMock,
         test_client: TestClient
@@ -215,10 +214,7 @@ class TestCategorisationApiRouterArticlesByCategory:
         )
         get_article_search_response_dict_by_category_mock.assert_called()
         _, kwargs = get_article_search_response_dict_by_category_mock.call_args
-        assert kwargs['article_fields_set'] == {
-            InternalArticleFieldNames.ARTICLE_DOI,
-            InternalArticleFieldNames.ARTICLE_TITLE
-        }
+        assert kwargs['article_fields_set'] == {'doi', 'title'}
 
     def test_should_raise_error_for_invalid_field_name(
         self,

--- a/tests/unit_tests/app/routers/api/classification/router_test.py
+++ b/tests/unit_tests/app/routers/api/classification/router_test.py
@@ -136,7 +136,7 @@ class TestClassificationApiRouterClassificationList:
         response.raise_for_status()
         assert response.json() == CATEGORISATION_RESPONSE_DICT_1
 
-    def test_should_pass_is_evaluated_filter_to_provider(
+    def test_should_pass_has_evaluations_filter_to_provider(
         self,
         get_classification_list_response_dict_mock: AsyncMock,
         test_client: TestClient
@@ -146,7 +146,7 @@ class TestClassificationApiRouterClassificationList:
         )
         test_client.get(
             '/classification/v1/classifications',
-            params={'filter[is_evaluated]': 'true'}
+            params={'filter[has_evaluations]': 'true'}
         )
         _, kwargs = get_classification_list_response_dict_mock.call_args
         filter_parameters: OpenSearchFilterParameters = kwargs['filter_parameters']
@@ -200,7 +200,7 @@ class TestClassificationApiRouterArticlesByCategory:
         response.raise_for_status()
         assert response.json() == ARTICLE_SEARCH_RESPONSE_DICT_1
 
-    def test_should_pass_is_evaluated_and_category_filter_to_provider(
+    def test_should_pass_has_evaluations_and_category_filter_to_provider(
         self,
         get_article_search_response_dict_by_category_mock: AsyncMock,
         test_client: TestClient
@@ -210,7 +210,7 @@ class TestClassificationApiRouterArticlesByCategory:
         )
         test_client.get(
             '/classification/v1/articles/by/category',
-            params={'category': 'Category 1', 'filter[is_evaluated]': 'true'}
+            params={'category': 'Category 1', 'filter[has_evaluations]': 'true'}
         )
         _, kwargs = get_article_search_response_dict_by_category_mock.call_args
         filter_parameters: OpenSearchFilterParameters = kwargs['filter_parameters']

--- a/tests/unit_tests/app/routers/api/classification/router_test.py
+++ b/tests/unit_tests/app/routers/api/classification/router_test.py
@@ -123,7 +123,7 @@ class TestGetNotFoundErrorJsonResponseDict:
         }
 
 
-class TestClassificationApiRouter:
+class TestClassificationApiRouterClassificationList:
     def test_should_provide_classification_list_response(
         self,
         get_classification_list_response_dict_mock: AsyncMock,
@@ -131,12 +131,29 @@ class TestClassificationApiRouter:
     ):
         get_classification_list_response_dict_mock.return_value = CATEGORISATION_RESPONSE_DICT_1
         response = test_client.get(
-            '/classification/v1/classifications',
-            params={'article_doi': DOI_1}
+            '/classification/v1/classifications'
         )
         response.raise_for_status()
         assert response.json() == CATEGORISATION_RESPONSE_DICT_1
 
+    def test_should_pass_is_evaluated_filter_to_provider(
+        self,
+        get_classification_list_response_dict_mock: AsyncMock,
+        test_client: TestClient
+    ):
+        get_classification_list_response_dict_mock.return_value = (
+            ARTICLE_SEARCH_RESPONSE_DICT_1
+        )
+        test_client.get(
+            '/classification/v1/classifications',
+            params={'filter[is_evaluated]': 'true'}
+        )
+        _, kwargs = get_classification_list_response_dict_mock.call_args
+        filter_parameters: OpenSearchFilterParameters = kwargs['filter_parameters']
+        assert filter_parameters.evaluated_only
+
+
+class TestClassificationApiRouterClassificationListByDoi:
     def test_should_provide_classification_response(
         self,
         get_classification_response_dict_by_doi_mock: AsyncMock,
@@ -183,7 +200,7 @@ class TestClassificationApiRouterArticlesByCategory:
         response.raise_for_status()
         assert response.json() == ARTICLE_SEARCH_RESPONSE_DICT_1
 
-    def test_should_pass_evaluated_only_and_category_filter_to_provider(
+    def test_should_pass_is_evaluated_and_category_filter_to_provider(
         self,
         get_article_search_response_dict_by_category_mock: AsyncMock,
         test_client: TestClient

--- a/tests/unit_tests/app/routers/api/classification/router_test.py
+++ b/tests/unit_tests/app/routers/api/classification/router_test.py
@@ -23,6 +23,7 @@ from sciety_labs.app.routers.api.classification.typing import (
 )
 from sciety_labs.app.routers.api.utils.validation import InvalidApiFieldsError
 from sciety_labs.models.article import InternalArticleFieldNames
+from sciety_labs.providers.opensearch.utils import OpenSearchFilterParameters
 
 
 LOGGER = logging.getLogger(__name__)
@@ -182,6 +183,22 @@ class TestCategorisationApiRouterArticlesByCategory:
         )
         response.raise_for_status()
         assert response.json() == ARTICLE_SEARCH_RESPONSE_DICT_1
+
+    def test_should_pass_evaluated_only_filter_to_provider(
+        self,
+        get_article_search_response_dict_by_category_mock: AsyncMock,
+        test_client: TestClient
+    ):
+        get_article_search_response_dict_by_category_mock.return_value = (
+            ARTICLE_SEARCH_RESPONSE_DICT_1
+        )
+        test_client.get(
+            '/classification/v1/articles/by/category',
+            params={'category': 'Category 1', 'evaluated_only': 'true'}
+        )
+        _, kwargs = get_article_search_response_dict_by_category_mock.call_args
+        filter_parameters: OpenSearchFilterParameters = kwargs['filter_parameters']
+        assert filter_parameters.evaluated_only
 
     def test_should_pass_mapped_api_fields_to_provider(
         self,


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/881

This is an attempt to follow JSON:API recommendations better.
Although it is more difficult for booleans, `has_evaluations` has a different semantics to `evaluated_only`.