### PR TITLE
Only preload Google Sheets data

### DIFF
--- a/sciety_labs/app/app_update_manager.py
+++ b/sciety_labs/app/app_update_manager.py
@@ -20,8 +20,12 @@ class AppUpdateManager:
         )
         self.app_providers_and_models.lists_model.apply_events(_sciety_event_dict_list)
         self.app_providers_and_models.evaluation_stats_model.apply_events(_sciety_event_dict_list)
-        self.app_providers_and_models.google_sheet_article_image_provider.refresh()
-        self.app_providers_and_models.google_sheet_list_image_provider.refresh()
+        if preload_only:
+            self.app_providers_and_models.google_sheet_article_image_provider.preload()
+            self.app_providers_and_models.google_sheet_list_image_provider.preload()
+        else:
+            self.app_providers_and_models.google_sheet_article_image_provider.refresh()
+            self.app_providers_and_models.google_sheet_list_image_provider.refresh()
 
     def check_or_reload_data_no_fail(self):
         try:

--- a/sciety_labs/providers/google_sheet_image.py
+++ b/sciety_labs/providers/google_sheet_image.py
@@ -67,6 +67,9 @@ class GoogleSheetImageProvider:
             load_fn=self.load_mapping
         )
 
+    def preload(self):
+        self.get_mapping()
+
     def refresh(self):
         self.article_image_mapping_cache.reload(
             load_fn=self.load_mapping


### PR DESCRIPTION
This reduces startup time during development. It also avoids an issue with the Google Sheets API due to frequent restarts during development.