### PR TITLE
Fixed API returns 400 for OpenSearch connection error

### DIFF
--- a/sciety_labs/app/routers/api/utils/jsonapi.py
+++ b/sciety_labs/app/routers/api/utils/jsonapi.py
@@ -72,14 +72,20 @@ def get_default_jsonapi_error_json_response_dict(
     }
 
 
-async def default_async_jsonapi_exception_handler(
-    request: fastapi.Request,  # pylint: disable=unused-argument
+def get_default_jsonapi_error_json_response(
     exc: Exception
 ) -> fastapi.responses.JSONResponse:
     return fastapi.responses.JSONResponse(
         get_default_jsonapi_error_json_response_dict(exc),
         status_code=400
     )
+
+
+async def default_async_jsonapi_exception_handler(
+    request: fastapi.Request,  # pylint: disable=unused-argument
+    exc: Exception
+) -> fastapi.responses.JSONResponse:
+    return get_default_jsonapi_error_json_response(exc)
 
 
 def get_async_exception_handler(

--- a/tests/unit_tests/app/routers/api/utils/jsonapi_test.py
+++ b/tests/unit_tests/app/routers/api/utils/jsonapi_test.py
@@ -15,6 +15,7 @@ class TestGetDefaultJsonApiErrorJsonResponse:
         json_response = get_default_jsonapi_error_json_response(
             exception
         )
+        assert json_response.status_code == 500
         assert json.loads(json_response.body) == {
             'errors': [{
                 'title': 'AssertionError',
@@ -31,6 +32,7 @@ class TestGetDefaultJsonApiErrorJsonResponse:
         json_response = get_default_jsonapi_error_json_response(
             exception
         )
+        assert json_response.status_code == 123
         assert json.loads(json_response.body) == {
             'errors': [{
                 'title': 'HTTPException',
@@ -47,6 +49,7 @@ class TestGetDefaultJsonApiErrorJsonResponse:
             exception
         )
         LOGGER.debug('json_response: %r', json_response)
+        assert json_response.status_code == 400
         assert json.loads(json_response.body) == {
             'errors': [{
                 'title': 'RequestValidationError',

--- a/tests/unit_tests/app/routers/api/utils/jsonapi_test.py
+++ b/tests/unit_tests/app/routers/api/utils/jsonapi_test.py
@@ -1,19 +1,21 @@
+import json
 import logging
 
 import fastapi
 
-from sciety_labs.app.routers.api.utils.jsonapi import get_default_jsonapi_error_json_response_dict
+from sciety_labs.app.routers.api.utils.jsonapi import get_default_jsonapi_error_json_response
 
 
 LOGGER = logging.getLogger(__name__)
 
 
-class TestGetDefaultJsonApiErrorJsonResponseDict:
+class TestGetDefaultJsonApiErrorJsonResponse:
     def test_should_support_generic_exception(self):
         exception = AssertionError('test')
-        assert get_default_jsonapi_error_json_response_dict(
+        json_response = get_default_jsonapi_error_json_response(
             exception
-        ) == {
+        )
+        assert json.loads(json_response.body) == {
             'errors': [{
                 'title': 'AssertionError',
                 'detail': 'test',
@@ -26,9 +28,10 @@ class TestGetDefaultJsonApiErrorJsonResponseDict:
             status_code=123,
             detail='Error details 1'
         )
-        assert get_default_jsonapi_error_json_response_dict(
+        json_response = get_default_jsonapi_error_json_response(
             exception
-        ) == {
+        )
+        assert json.loads(json_response.body) == {
             'errors': [{
                 'title': 'HTTPException',
                 'detail': 'Error details 1',
@@ -40,11 +43,11 @@ class TestGetDefaultJsonApiErrorJsonResponseDict:
         exception = fastapi.exceptions.RequestValidationError(
             errors=[{'key': 'Error 1'}]
         )
-        json_response_dict = get_default_jsonapi_error_json_response_dict(
+        json_response = get_default_jsonapi_error_json_response(
             exception
         )
-        LOGGER.debug('json_response_dict: %r', json_response_dict)
-        assert json_response_dict == {
+        LOGGER.debug('json_response: %r', json_response)
+        assert json.loads(json_response.body) == {
             'errors': [{
                 'title': 'RequestValidationError',
                 'detail': (


### PR DESCRIPTION
OpenSearch connection errors were responding with a `400` status code, even though the JSON response listed `500`.
This fixes it.