### PR TITLE
Rename API response types from Categorisation to Classification to match endpoint naming

### DIFF
--- a/sciety_labs/app/routers/api/papers/providers.py
+++ b/sciety_labs/app/routers/api/papers/providers.py
@@ -9,8 +9,8 @@ from sciety_labs.app.routers.api.papers.typing import (
     PaperDict,
     PaperResponseDict,
     PaperSearchResponseDict,
-    CategorisationDict,
-    CategorisationResponseDict
+    ClassificationDict,
+    ClassificationResponseDict
 )
 from sciety_labs.models.article import InternalArticleFieldNames, KnownDoiPrefix
 from sciety_labs.providers.opensearch.typing import (
@@ -109,7 +109,7 @@ def get_paper_search_by_category_opensearch_query_dict(
 
 def get_classification_dict_for_crossref_group_title(
     group_title: str
-) -> CategorisationDict:
+) -> ClassificationDict:
     return {
         'type': 'category',
         'id': group_title,
@@ -122,7 +122,7 @@ def get_classification_dict_for_crossref_group_title(
 
 def get_classification_response_dict_for_opensearch_aggregations_response_dict(
     response_dict: dict
-) -> CategorisationResponseDict:
+) -> ClassificationResponseDict:
     group_titles = [
         bucket['key']
         for bucket in response_dict['aggregations']['group_title']['buckets']
@@ -138,7 +138,7 @@ def get_classification_response_dict_for_opensearch_aggregations_response_dict(
 def get_classification_response_dict_for_opensearch_document_dict(
     document_dict: dict,
     doi: str
-) -> CategorisationResponseDict:
+) -> ClassificationResponseDict:
     crossref_opensearch_dict = document_dict.get('crossref')
     group_title = (
         crossref_opensearch_dict
@@ -249,7 +249,7 @@ class AsyncOpenSearchPapersProvider:
         self,
         filter_parameters: OpenSearchFilterParameters,
         headers: Optional[Mapping[str, str]] = None
-    ) -> CategorisationResponseDict:
+    ) -> ClassificationResponseDict:
         LOGGER.info('filter_parameters: %r', filter_parameters)
         LOGGER.debug('async_opensearch_client: %r', self.async_opensearch_client)
         opensearch_aggregations_response_dict = await self.async_opensearch_client.search(
@@ -267,7 +267,7 @@ class AsyncOpenSearchPapersProvider:
         self,
         doi: str,
         headers: Optional[Mapping[str, str]] = None
-    ) -> CategorisationResponseDict:
+    ) -> ClassificationResponseDict:
         LOGGER.debug('async_opensearch_client: %r', self.async_opensearch_client)
         LOGGER.debug(
             'async_opensearch_client.get_source: %r',

--- a/sciety_labs/app/routers/api/papers/router.py
+++ b/sciety_labs/app/routers/api/papers/router.py
@@ -18,7 +18,7 @@ from sciety_labs.app.routers.api.papers.providers import (
 )
 from sciety_labs.app.routers.api.papers.typing import (
     PaperSearchResponseDict,
-    CategorisationResponseDict
+    ClassificationResponseDict
 )
 from sciety_labs.providers.opensearch.utils import (
     OpenSearchFilterParameters,
@@ -30,7 +30,7 @@ from sciety_labs.utils.fastapi import get_cache_control_headers_for_request
 LOGGER = logging.getLogger(__name__)
 
 
-CATEGORISATION_BY_DOI_API_EXAMPLE_200_RESPONSE: CategorisationResponseDict = {
+CATEGORISATION_BY_DOI_API_EXAMPLE_200_RESPONSE: ClassificationResponseDict = {
     'data': [{
         'type': 'category',
         'id': 'Pain Medicine',
@@ -69,7 +69,7 @@ CATEGORISATION_BY_DOI_API_EXAMPLE_RESPONSES: dict = {
 }
 
 
-CATEGORISATION_LIST_API_EXAMPLE_200_RESPONSE: CategorisationResponseDict = {
+CATEGORISATION_LIST_API_EXAMPLE_200_RESPONSE: ClassificationResponseDict = {
     'data': [{
         'type': 'category',
         'id': 'Neuroscience',
@@ -233,7 +233,7 @@ def create_api_papers_router(
 
     @router.get(
         '/papers/v1/preprints/classifications',
-        response_model=CategorisationResponseDict,
+        response_model=ClassificationResponseDict,
         responses=CATEGORISATION_LIST_API_EXAMPLE_RESPONSES
     )
     async def classifications_list(
@@ -252,7 +252,7 @@ def create_api_papers_router(
 
     @router.get(
         '/papers/v1/preprints/classifications/by/doi/{doi:path}',
-        response_model=CategorisationResponseDict,
+        response_model=ClassificationResponseDict,
         responses=CATEGORISATION_BY_DOI_API_EXAMPLE_RESPONSES
     )
     async def classifications_by_doi(

--- a/sciety_labs/app/routers/api/papers/typing.py
+++ b/sciety_labs/app/routers/api/papers/typing.py
@@ -2,15 +2,15 @@ from typing import Optional, Sequence
 from typing_extensions import NotRequired, TypedDict
 
 
-class CategorisationAttributesDict(TypedDict):
+class ClassificationAttributesDict(TypedDict):
     display_name: str
     source_id: str
 
 
-class CategorisationDict(TypedDict):
+class ClassificationDict(TypedDict):
     type: str
     id: str
-    attributes: CategorisationAttributesDict
+    attributes: ClassificationAttributesDict
 
 
 class PaperAttributesDict(TypedDict):
@@ -20,7 +20,7 @@ class PaperAttributesDict(TypedDict):
     evaluation_count: NotRequired[Optional[int]]
     has_evaluations: NotRequired[Optional[bool]]
     latest_evaluation_activity_timestamp: NotRequired[Optional[str]]
-    classifications: NotRequired[Sequence[CategorisationDict]]
+    classifications: NotRequired[Sequence[ClassificationDict]]
 
 
 class PaperDict(TypedDict):
@@ -29,8 +29,8 @@ class PaperDict(TypedDict):
     attributes: PaperAttributesDict
 
 
-class CategorisationResponseDict(TypedDict):
-    data: NotRequired[Sequence[CategorisationDict]]
+class ClassificationResponseDict(TypedDict):
+    data: NotRequired[Sequence[ClassificationDict]]
 
 
 class PaperResponseDict(TypedDict):

--- a/sciety_labs/providers/papers/async_papers.py
+++ b/sciety_labs/providers/papers/async_papers.py
@@ -3,7 +3,7 @@ import logging
 from typing import Mapping, Optional, Sequence
 
 from sciety_labs.app.routers.api.papers.typing import (
-    CategorisationResponseDict,
+    ClassificationResponseDict,
     PaperDict,
     PaperSearchResponseDict
 )
@@ -27,7 +27,7 @@ class PageNumberBasedArticleSearchResultList:
 
 
 def get_category_display_names_for_classification_response_dict(
-    classification_response_dict: CategorisationResponseDict
+    classification_response_dict: ClassificationResponseDict
 ) -> Sequence[str]:
     return [
         classification_dict['attributes']['display_name']
@@ -104,7 +104,7 @@ class AsyncPapersProvider(AsyncRequestsProvider):
                     await response.read()
                 )
             response.raise_for_status()
-            response_json: CategorisationResponseDict = await response.json()
+            response_json: ClassificationResponseDict = await response.json()
             LOGGER.debug('Categories, response_json=%r', response_json)
             return get_category_display_names_for_classification_response_dict(
                 response_json

--- a/tests/regression_tests/api_papers_test.py
+++ b/tests/regression_tests/api_papers_test.py
@@ -8,7 +8,7 @@ from requests import Session
 
 from sciety_labs.app.routers.api.papers.typing import (
     PaperSearchResponseDict,
-    CategorisationResponseDict
+    ClassificationResponseDict
 )
 
 
@@ -26,17 +26,17 @@ NON_BIORXIV_MEDRXIV_DOI_WITH_GROUP_TITLE_1 = '10.31234/osf.io/2hv6x'
 @pytest.fixture(name='classification_list_response_dict', scope='session')
 def _classification_list_response_dict(
     regression_test_session: Session
-) -> CategorisationResponseDict:
+) -> ClassificationResponseDict:
     response = regression_test_session.get(
         '/api/papers/v1/preprints/classifications'
     )
     response.raise_for_status()
-    response_json: CategorisationResponseDict = response.json()
+    response_json: ClassificationResponseDict = response.json()
     return response_json
 
 
 def get_category_set(
-    classification_list_response_dict: CategorisationResponseDict
+    classification_list_response_dict: ClassificationResponseDict
 ) -> Set[str]:
     return {
         classification['attributes']['display_name']
@@ -48,20 +48,20 @@ def get_category_set(
 class TestApiCategorisationList:
     def test_should_return_non_empty_list(
         self,
-        classification_list_response_dict: CategorisationResponseDict
+        classification_list_response_dict: ClassificationResponseDict
     ):
         assert len(classification_list_response_dict['data']) > 0
 
     def test_should_contain_biophysics(
         self,
-        classification_list_response_dict: CategorisationResponseDict
+        classification_list_response_dict: ClassificationResponseDict
     ):
         category_set = get_category_set(classification_list_response_dict)
         assert Categories.BIOPHYSICS in category_set
 
     def test_should_not_contain_non_biorxiv_medrxiv_group_title(
         self,
-        classification_list_response_dict: CategorisationResponseDict
+        classification_list_response_dict: ClassificationResponseDict
     ):
         category_set = get_category_set(classification_list_response_dict)
         assert NON_BIORXIV_MEDRXIV_GROUP_TITLE_1 not in category_set
@@ -96,7 +96,7 @@ class TestApiCategorisationsByDoi:
             f'/api/papers/v1/preprints/classifications/by/doi/{BIOPHYISICS_DOI_1}'
         )
         response.raise_for_status()
-        response_json: CategorisationResponseDict = response.json()
+        response_json: ClassificationResponseDict = response.json()
         assert len(response_json['data']) > 0
         assert response_json['data'] == [
             {
@@ -120,5 +120,5 @@ class TestApiCategorisationsByDoi:
             )
         )
         response.raise_for_status()
-        response_json: CategorisationResponseDict = response.json()
+        response_json: ClassificationResponseDict = response.json()
         assert len(response_json['data']) == 0

--- a/tests/regression_tests/api_papers_test.py
+++ b/tests/regression_tests/api_papers_test.py
@@ -45,7 +45,7 @@ def get_category_set(
     }
 
 
-class TestApiCategorisationList:
+class TestApiClassifcationList:
     def test_should_return_non_empty_list(
         self,
         classification_list_response_dict: ClassificationResponseDict
@@ -90,7 +90,7 @@ class TestApiPreprints:
         assert len(response_json['data']) == 0
 
 
-class TestApiCategorisationsByDoi:
+class TestApiClassificationsByDoi:
     def test_should_list_classifications_by_doi(self, regression_test_session: Session):
         response = regression_test_session.get(
             f'/api/papers/v1/preprints/classifications/by/doi/{BIOPHYISICS_DOI_1}'

--- a/tests/unit_tests/app/routers/api/papers/router_test.py
+++ b/tests/unit_tests/app/routers/api/papers/router_test.py
@@ -19,7 +19,7 @@ from sciety_labs.app.routers.api.papers.router import (
 )
 from sciety_labs.app.routers.api.papers.typing import (
     PaperSearchResponseDict,
-    CategorisationResponseDict
+    ClassificationResponseDict
 )
 from sciety_labs.app.routers.api.utils.validation import InvalidApiFieldsError
 from sciety_labs.providers.opensearch.utils import OpenSearchFilterParameters
@@ -32,7 +32,7 @@ DOI_1 = '10.12345/test-doi-1'
 
 INVALID_DOI_1 = 'invalid-doi-1'
 
-CATEGORISATION_RESPONSE_DICT_1: CategorisationResponseDict = {
+CATEGORISATION_RESPONSE_DICT_1: ClassificationResponseDict = {
     'data': [{
         'type': 'category',
         'id': 'Category 1',

--- a/tests/unit_tests/providers/papers/async_papers_test.py
+++ b/tests/unit_tests/providers/papers/async_papers_test.py
@@ -6,7 +6,7 @@ import aiohttp
 import pytest
 
 from sciety_labs.app.routers.api.papers.typing import (
-    CategorisationResponseDict,
+    ClassificationResponseDict,
     PaperSearchResponseDict
 )
 from sciety_labs.providers.papers.async_papers import (
@@ -24,7 +24,7 @@ LOGGER = logging.getLogger(__name__)
 DOI_1 = '10.12345/doi_1'
 
 
-CLASSIFICATIONS_RESPONSE_DICT_1: CategorisationResponseDict = {
+CLASSIFICATIONS_RESPONSE_DICT_1: ClassificationResponseDict = {
     'data': [{
         'id': 'some id',
         'type': 'category',


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/881