### PR TITLE
Link back to Sciety on categories articles page, depending on `from_sciety` query parameter

### DIFF
--- a/sciety_labs/app/routers/categories.py
+++ b/sciety_labs/app/routers/categories.py
@@ -1,6 +1,7 @@
 import logging
 
 from fastapi import APIRouter, Request
+import fastapi
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
@@ -47,6 +48,8 @@ def create_categories_router(
         request: Request,
         category: str,
         pagination_parameters: AnnotatedPaginationParameters,
+        from_sciety: bool = False,
+        from_sciety_alias: bool = fastapi.Query(False, alias='from-sciety'),
         evaluated_only: bool = True
     ):
         search_results_list = await (
@@ -81,6 +84,7 @@ def create_categories_router(
                     category
                 ),
                 'category_display_name': category,
+                'from_sciety': from_sciety or from_sciety_alias,
                 'article_list_content': article_mention_with_article_meta,
                 'pagination': url_pagination_state
             }

--- a/sciety_labs/app/routers/categories.py
+++ b/sciety_labs/app/routers/categories.py
@@ -1,12 +1,15 @@
 import logging
 
 from fastapi import APIRouter, Request
-import fastapi
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
 from sciety_labs.app.app_providers_and_models import AppProvidersAndModels
-from sciety_labs.app.utils.common import AnnotatedPaginationParameters, get_page_title
+from sciety_labs.app.utils.common import (
+    AnnotatedFromScietyParameter,
+    AnnotatedPaginationParameters,
+    get_page_title
+)
 from sciety_labs.providers.papers.async_papers import PageNumberBasedPaginationParameters
 from sciety_labs.utils.pagination import get_url_pagination_state_for_pagination_parameters
 
@@ -48,8 +51,7 @@ def create_categories_router(
         request: Request,
         category: str,
         pagination_parameters: AnnotatedPaginationParameters,
-        from_sciety: bool = False,
-        from_sciety_alias: bool = fastapi.Query(False, alias='from-sciety'),
+        from_sciety: AnnotatedFromScietyParameter,
         evaluated_only: bool = True
     ):
         search_results_list = await (
@@ -84,7 +86,7 @@ def create_categories_router(
                     category
                 ),
                 'category_display_name': category,
-                'from_sciety': from_sciety or from_sciety_alias,
+                'from_sciety': from_sciety,
                 'article_list_content': article_mention_with_article_meta,
                 'pagination': url_pagination_state
             }

--- a/sciety_labs/app/routers/list_by_id.py
+++ b/sciety_labs/app/routers/list_by_id.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
@@ -9,6 +9,7 @@ from sciety_labs.app.app_providers_and_models import AppProvidersAndModels
 from sciety_labs.app.utils.common import (
     DEFAULT_ARTICLE_RECOMMENDATION_RSS_ITEM_COUNT,
     DEFAULT_ITEMS_PER_PAGE,
+    AnnotatedFromScietyParameter,
     AnnotatedPaginationParameters,
     get_owner_url,
     get_page_title,
@@ -114,8 +115,7 @@ def create_list_by_id_router(
         request: Request,
         list_id: str,
         pagination_parameters: AnnotatedPaginationParameters,
-        from_sciety: bool = False,
-        from_sciety_alias: bool = Query(False, alias='from-sciety'),
+        from_sciety: AnnotatedFromScietyParameter,
         max_recommendations: int = DEFAULT_SEMANTIC_SCHOLAR_MAX_RECOMMENDATIONS,
         fragment: bool = False
     ):
@@ -136,7 +136,7 @@ def create_list_by_id_router(
                     'rss_url': get_rss_url(request),
                     'owner_url': get_owner_url(list_summary_data.owner),
                     'list_summary_data': list_summary_data,
-                    'from_sciety': from_sciety or from_sciety_alias,
+                    'from_sciety': from_sciety,
                     'article_recommendation_fragment_url': article_recommendation_fragment_url
                 }
             )
@@ -167,7 +167,7 @@ def create_list_by_id_router(
                 'page_title': get_page_title(
                     f'Article recommendations for {list_summary_data.list_meta.list_name}'
                 ),
-                'from_sciety': from_sciety or from_sciety_alias,
+                'from_sciety': from_sciety,
                 'article_list_content': article_recommendation_with_article_meta,
                 'pagination': url_pagination_state
             }

--- a/sciety_labs/app/utils/common.py
+++ b/sciety_labs/app/utils/common.py
@@ -1,6 +1,7 @@
 from typing import Annotated, Optional
 
 from fastapi import Depends, Request
+import fastapi
 
 from sciety_labs.models.lists import OwnerMetaData, OwnerTypes
 from sciety_labs.providers.semantic_scholar import DEFAULT_SEMANTIC_SCHOLAR_MAX_RECOMMENDATIONS
@@ -57,4 +58,17 @@ async def get_pagination_parameters(
 
 AnnotatedPaginationParameters = Annotated[
     UrlPaginationParameters, Depends(get_pagination_parameters)
+]
+
+
+async def get_from_sciety_parameter(
+    from_sciety: bool = False,
+    from_sciety_alias: bool = fastapi.Query(False, alias='from-sciety'),
+) -> bool:
+    return from_sciety or from_sciety_alias
+
+
+AnnotatedFromScietyParameter = Annotated[
+    bool,
+    Depends(get_from_sciety_parameter)
 ]


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/881

This allows Sciey to temporarily link to the categories articles page, while sending users back to Sciety.
(Similar to the related articles for a list before)