### PR TITLE
Implement sort parameter for Preprints Search API

### DIFF
--- a/sciety_labs/app/routers/api/article_recommendation.py
+++ b/sciety_labs/app/routers/api/article_recommendation.py
@@ -218,7 +218,7 @@ ARTICLE_RECOMMENDATION_FIELDS_BY_API_FIELD_NAME: Mapping[str, Sequence[str]] = {
 def validate_api_fields(fields_set: Set[str]):
     invalid_field_names = fields_set - set(ARTICLE_RECOMMENDATION_FIELDS_BY_API_FIELD_NAME.keys())
     if invalid_field_names:
-        raise InvalidApiFieldsError(invalid_field_names)
+        raise InvalidApiFieldsError(invalid_field_names, query_parameter_name='fields')
 
 
 def get_requested_fields_for_api_field_set(

--- a/sciety_labs/app/routers/api/papers/router.py
+++ b/sciety_labs/app/routers/api/papers/router.py
@@ -162,6 +162,33 @@ PAPER_FIELDS_FASTAPI_QUERY = fastapi.Query(
     ]
 )
 
+SUPPORTED_PAPER_SORT_FIELDS = [
+    'publication_date'
+]
+
+SUPPORTED_PAPER_SORT_FIELDS_AS_MARKDOWN_LIST = '\n'.join([
+    f'- `{field_name}`'
+    for field_name in SUPPORTED_PAPER_SORT_FIELDS
+])
+
+PAPER_SEARCH_SORT_FIELDS_FASTAPI_QUERY = fastapi.Query(
+    alias='sort',
+    default='',
+    description='\n'.join([
+        'By default, sorting will be by score (descending).',
+        '',
+        'Comma separated list of fields to sort by.',
+        'The sort order for each sort field is ascending unless it is prefixed with a minus.',
+        '',
+        'The following fields can be specified to sort by:',
+        '',
+        SUPPORTED_PAPER_SORT_FIELDS_AS_MARKDOWN_LIST
+    ]),
+    examples=[  # Note: These only seem to appear in /redoc
+        '-publication_date'
+    ]
+)
+
 
 PREPRINTS_SEARCH_API_DESCRIPTION = textwrap.dedent(
     '''
@@ -328,8 +355,10 @@ def create_api_papers_router(
         evaluated_only: bool = fastapi.Query(alias='filter[evaluated_only]', default=False),
         page_size: int = fastapi.Query(alias='page[size]', default=10),
         page_number: int = fastapi.Query(alias='page[number]', ge=1, default=1),
-        api_paper_fields_csv: str = PAPER_FIELDS_FASTAPI_QUERY
+        api_paper_fields_csv: str = PAPER_FIELDS_FASTAPI_QUERY,
+        api_paper_sort_fields_csv: str = PAPER_SEARCH_SORT_FIELDS_FASTAPI_QUERY
     ):
+        LOGGER.info('api_paper_sort_fields_csv: %r', api_paper_sort_fields_csv)
         api_paper_fields_set = set(api_paper_fields_csv.split(','))
         validate_api_fields(api_paper_fields_set, valid_values=ALL_PAPER_FIELDS)
         return await (

--- a/sciety_labs/app/routers/api/papers/router.py
+++ b/sciety_labs/app/routers/api/papers/router.py
@@ -193,7 +193,9 @@ PAPER_SEARCH_SORT_FIELDS_FASTAPI_QUERY = fastapi.Query(
         '',
         'The following fields can be specified to sort by:',
         '',
-        SUPPORTED_API_PAPER_SORT_FIELDS_AS_MARKDOWN_LIST
+        SUPPORTED_API_PAPER_SORT_FIELDS_AS_MARKDOWN_LIST,
+        '',
+        'For example to sort by publication date descending, specify: `-publication_date`'
     ]),
     examples=[  # Note: These only seem to appear in /redoc
         '-publication_date'

--- a/sciety_labs/app/routers/api/papers/router.py
+++ b/sciety_labs/app/routers/api/papers/router.py
@@ -28,6 +28,7 @@ from sciety_labs.providers.opensearch.utils import (
     OpenSearchSortParameters
 )
 from sciety_labs.utils.fastapi import get_cache_control_headers_for_request
+from sciety_labs.utils.text import parse_csv
 
 
 LOGGER = logging.getLogger(__name__)
@@ -361,6 +362,8 @@ def create_api_papers_router(
         LOGGER.info('api_paper_sort_fields_csv: %r', api_paper_sort_fields_csv)
         api_paper_fields_set = set(api_paper_fields_csv.split(','))
         validate_api_fields(api_paper_fields_set, valid_values=ALL_PAPER_FIELDS)
+        api_paper_sort_fields = parse_csv(api_paper_sort_fields_csv)
+        validate_api_fields(set(api_paper_sort_fields), valid_values=SUPPORTED_PAPER_SORT_FIELDS)
         return await (
             async_opensearch_papers_provider
             .get_paper_search_response_dict(

--- a/sciety_labs/app/routers/api/papers/router.py
+++ b/sciety_labs/app/routers/api/papers/router.py
@@ -241,10 +241,11 @@ def get_invalid_api_fields_json_response_dict(
         'errors': [{
             'title': 'Invalid fields',
             'detail': (
-                f'Invalid fields for {exception.query_parameter_name} parameter specified: '
+                'Invalid fields specified: '
                 + ','.join(exception.invalid_field_names)
             ),
-            'status': '400'
+            'status': '400',
+            'source': {'parameter': exception.query_parameter_name}
         }]
     }
 

--- a/sciety_labs/app/routers/api/papers/router.py
+++ b/sciety_labs/app/routers/api/papers/router.py
@@ -240,7 +240,10 @@ def get_invalid_api_fields_json_response_dict(
     return {
         'errors': [{
             'title': 'Invalid fields',
-            'detail': f'Invalid API fields: {",".join(exception.invalid_field_names)}',
+            'detail': (
+                f'Invalid fields for {exception.query_parameter_name} parameter specified: '
+                + ','.join(exception.invalid_field_names)
+            ),
             'status': '400'
         }]
     }
@@ -370,7 +373,11 @@ def create_api_papers_router(
         api_paper_fields_csv: str = PAPER_FIELDS_FASTAPI_QUERY
     ):
         api_paper_fields_set = set(api_paper_fields_csv.split(','))
-        validate_api_fields(api_paper_fields_set, valid_values=ALL_PAPER_FIELDS)
+        validate_api_fields(
+            api_paper_fields_set,
+            valid_values=ALL_PAPER_FIELDS,
+            query_parameter_name=PAPER_FIELDS_FASTAPI_QUERY.alias
+        )
         return await (
             async_opensearch_papers_provider
             .get_paper_search_response_dict(
@@ -408,12 +415,17 @@ def create_api_papers_router(
     ):
         LOGGER.info('prefixed_api_paper_sort_fields_csv: %r', prefixed_api_paper_sort_fields_csv)
         api_paper_fields_set = set(api_paper_fields_csv.split(','))
-        validate_api_fields(api_paper_fields_set, valid_values=ALL_PAPER_FIELDS)
+        validate_api_fields(
+            api_paper_fields_set,
+            valid_values=ALL_PAPER_FIELDS,
+            query_parameter_name=PAPER_FIELDS_FASTAPI_QUERY.alias
+        )
         api_paper_sort_fields = parse_csv(prefixed_api_paper_sort_fields_csv)
         LOGGER.debug('api_paper_sort_fields: %r', api_paper_sort_fields)
         validate_api_fields(
             set(api_paper_sort_fields),
-            valid_values=SUPPORTED_PREFIXED_API_PAPER_SORT_FIELDS
+            valid_values=SUPPORTED_PREFIXED_API_PAPER_SORT_FIELDS,
+            query_parameter_name=PAPER_SEARCH_SORT_FIELDS_FASTAPI_QUERY.alias
         )
         return await (
             async_opensearch_papers_provider

--- a/sciety_labs/app/routers/api/utils/jsonapi_typing.py
+++ b/sciety_labs/app/routers/api/utils/jsonapi_typing.py
@@ -5,11 +5,16 @@ from typing_extensions import NotRequired, TypedDict
 JsonMetaObjectDict = Mapping[str, Any]
 
 
+class JsonApiErrorSourceDict(TypedDict):
+    parameter: NotRequired[str]
+
+
 class JsonApiErrorDict(TypedDict):
     # https://jsonapi.org/format/#errors
     status: NotRequired[str]
     title: NotRequired[str]
     detail: NotRequired[str]
+    source: NotRequired[JsonApiErrorSourceDict]
     meta: NotRequired[JsonMetaObjectDict]
 
 

--- a/sciety_labs/app/routers/api/utils/validation.py
+++ b/sciety_labs/app/routers/api/utils/validation.py
@@ -2,14 +2,23 @@ from typing import Iterable, Set
 
 
 class InvalidApiFieldsError(ValueError):
-    def __init__(self, invalid_field_names: Set[str]):
+    def __init__(
+        self,
+        invalid_field_names: Set[str],
+        query_parameter_name: str
+    ):
         self.invalid_field_names = invalid_field_names
+        self.query_parameter_name = query_parameter_name
 
 
 def validate_api_fields(
     fields_set: Set[str],
-    valid_values: Iterable[str]
+    valid_values: Iterable[str],
+    query_parameter_name: str
 ):
     invalid_field_names = fields_set - set(valid_values)
     if invalid_field_names:
-        raise InvalidApiFieldsError(invalid_field_names)
+        raise InvalidApiFieldsError(
+            invalid_field_names=invalid_field_names,
+            query_parameter_name=query_parameter_name
+        )

--- a/sciety_labs/utils/text.py
+++ b/sciety_labs/utils/text.py
@@ -1,5 +1,5 @@
 import re
-from typing import Optional
+from typing import Optional, Sequence
 
 
 def remove_markup(text: str) -> str:
@@ -10,3 +10,9 @@ def remove_markup_or_none(text: Optional[str]) -> Optional[str]:
     if text is None:
         return None
     return re.sub(r'<[^>]+>', '', text)
+
+
+def parse_csv(text: str, delimiter: str = ',') -> Sequence[str]:
+    if not text:
+        return []
+    return text.split(sep=delimiter)

--- a/tests/unit_tests/app/routers/api/papers/router_test.py
+++ b/tests/unit_tests/app/routers/api/papers/router_test.py
@@ -314,7 +314,10 @@ class _BaseTestPapersApiRouterPreprints(ABC):
         response_json = response.json()
         LOGGER.debug('response_json: %r', response_json)
         assert response_json == get_invalid_api_fields_json_response_dict(
-            InvalidApiFieldsError({'invalid_1'})
+            InvalidApiFieldsError(
+                invalid_field_names={'invalid_1'},
+                query_parameter_name='fields[paper]'
+            )
         )
 
 
@@ -398,5 +401,8 @@ class TestPapersSearchApiRouterPreprints(_BaseTestPapersApiRouterPreprints):
         response_json = response.json()
         LOGGER.debug('response_json: %r', response_json)
         assert response_json == get_invalid_api_fields_json_response_dict(
-            InvalidApiFieldsError({'invalid_1'})
+            InvalidApiFieldsError(
+                invalid_field_names={'invalid_1'},
+                query_parameter_name='sort'
+            )
         )

--- a/tests/unit_tests/app/routers/api/papers/router_test.py
+++ b/tests/unit_tests/app/routers/api/papers/router_test.py
@@ -313,3 +313,25 @@ class TestPapersSearchApiRouterPreprints(_BaseTestPapersApiRouterPreprints):
         get_paper_search_response_dict_mock.assert_called()
         _, kwargs = get_paper_search_response_dict_mock.call_args
         assert kwargs['query'] == QUERY_1
+
+    def test_should_raise_error_for_invalid_sort_field_name(
+        self,
+        get_paper_search_response_dict_mock: AsyncMock,
+        test_client: TestClient
+    ):
+        get_paper_search_response_dict_mock.return_value = (
+            PAPER_SEARCH_RESPONSE_DICT_1
+        )
+        response = test_client.get(
+            self.get_url(),
+            params={
+                **self.get_default_params(),
+                'sort': 'invalid_1'
+            }
+        )
+        assert response.status_code == 400
+        response_json = response.json()
+        LOGGER.debug('response_json: %r', response_json)
+        assert response_json == get_invalid_api_fields_json_response_dict(
+            InvalidApiFieldsError({'invalid_1'})
+        )

--- a/tests/unit_tests/app/routers/api/papers/router_test.py
+++ b/tests/unit_tests/app/routers/api/papers/router_test.py
@@ -142,25 +142,25 @@ class TestGetOpenSearchSortParametersForApiPaperSortFieldList:
             sort_fields=[]
         )
 
-    def test_should_sort_by_publication_date_asc(self):
+    def test_should_sort_by_mapped_publication_date_asc(self):
         assert get_opensearch_sort_parameters_for_api_paper_sort_field_list(
             ['publication_date']
         ) == OpenSearchSortParameters(
             sort_fields=[
                 OpenSearchSortField(
-                    field_name='publication_date',
+                    field_name='europepmc.first_publication_date',
                     sort_order='asc'
                 )
             ]
         )
 
-    def test_should_sort_by_publication_date_desc(self):
+    def test_should_sort_by_mapped_publication_date_desc(self):
         assert get_opensearch_sort_parameters_for_api_paper_sort_field_list(
             ['-publication_date']
         ) == OpenSearchSortParameters(
             sort_fields=[
                 OpenSearchSortField(
-                    field_name='publication_date',
+                    field_name='europepmc.first_publication_date',
                     sort_order='desc'
                 )
             ]

--- a/tests/unit_tests/app/routers/api/papers/router_test.py
+++ b/tests/unit_tests/app/routers/api/papers/router_test.py
@@ -14,7 +14,7 @@ from sciety_labs.app.routers.api.papers.providers import (
 )
 import sciety_labs.app.routers.api.papers.router as router_module
 from sciety_labs.app.routers.api.papers.router import (
-    SUPPORTED_PAPER_SORT_FIELDS,
+    SUPPORTED_API_PAPER_SORT_FIELDS,
     create_api_papers_router,
     get_invalid_api_fields_json_response_dict,
     get_doi_not_found_error_json_response_dict,
@@ -63,7 +63,7 @@ PAPER_SEARCH_RESPONSE_DICT_1: PaperSearchResponseDict = {
 
 QUERY_1 = 'query 1'
 
-SUPPORTED_PAPER_SORT_FIELD_1 = SUPPORTED_PAPER_SORT_FIELDS[0]
+SUPPORTED_PAPER_SORT_FIELD_1 = SUPPORTED_API_PAPER_SORT_FIELDS[0]
 
 
 @pytest.fixture(name='async_opensearch_papers_provider_class_mock', autouse=True)

--- a/tests/unit_tests/app/routers/api/papers/router_test.py
+++ b/tests/unit_tests/app/routers/api/papers/router_test.py
@@ -14,16 +14,22 @@ from sciety_labs.app.routers.api.papers.providers import (
 )
 import sciety_labs.app.routers.api.papers.router as router_module
 from sciety_labs.app.routers.api.papers.router import (
+    SUPPORTED_PAPER_SORT_FIELDS,
     create_api_papers_router,
     get_invalid_api_fields_json_response_dict,
-    get_doi_not_found_error_json_response_dict
+    get_doi_not_found_error_json_response_dict,
+    get_opensearch_sort_parameters_for_api_paper_sort_field_list
 )
 from sciety_labs.app.routers.api.papers.typing import (
     PaperSearchResponseDict,
     ClassificationResponseDict
 )
 from sciety_labs.app.routers.api.utils.validation import InvalidApiFieldsError
-from sciety_labs.providers.opensearch.utils import OpenSearchFilterParameters
+from sciety_labs.providers.opensearch.utils import (
+    OpenSearchFilterParameters,
+    OpenSearchSortField,
+    OpenSearchSortParameters
+)
 
 
 LOGGER = logging.getLogger(__name__)
@@ -56,6 +62,8 @@ PAPER_SEARCH_RESPONSE_DICT_1: PaperSearchResponseDict = {
 }
 
 QUERY_1 = 'query 1'
+
+SUPPORTED_PAPER_SORT_FIELD_1 = SUPPORTED_PAPER_SORT_FIELDS[0]
 
 
 @pytest.fixture(name='async_opensearch_papers_provider_class_mock', autouse=True)
@@ -124,6 +132,39 @@ class TestGetNotFoundErrorJsonResponseDict:
                 'status': '404'
             }]
         }
+
+
+class TestGetOpenSearchSortParametersForApiPaperSortFieldList:
+    def test_should_be_empty_by_default(self):
+        assert get_opensearch_sort_parameters_for_api_paper_sort_field_list(
+            []
+        ) == OpenSearchSortParameters(
+            sort_fields=[]
+        )
+
+    def test_should_sort_by_publication_date_asc(self):
+        assert get_opensearch_sort_parameters_for_api_paper_sort_field_list(
+            ['publication_date']
+        ) == OpenSearchSortParameters(
+            sort_fields=[
+                OpenSearchSortField(
+                    field_name='publication_date',
+                    sort_order='asc'
+                )
+            ]
+        )
+
+    def test_should_sort_by_publication_date_desc(self):
+        assert get_opensearch_sort_parameters_for_api_paper_sort_field_list(
+            ['-publication_date']
+        ) == OpenSearchSortParameters(
+            sort_fields=[
+                OpenSearchSortField(
+                    field_name='publication_date',
+                    sort_order='desc'
+                )
+            ]
+        )
 
 
 class TestPapersApiRouterClassificationList:
@@ -313,6 +354,30 @@ class TestPapersSearchApiRouterPreprints(_BaseTestPapersApiRouterPreprints):
         get_paper_search_response_dict_mock.assert_called()
         _, kwargs = get_paper_search_response_dict_mock.call_args
         assert kwargs['query'] == QUERY_1
+
+    def test_should_pass_desc_sort_fields_to_provider(
+        self,
+        get_paper_search_response_dict_mock: AsyncMock,
+        test_client: TestClient
+    ):
+        get_paper_search_response_dict_mock.return_value = (
+            PAPER_SEARCH_RESPONSE_DICT_1
+        )
+        response = test_client.get(
+            self.get_url(),
+            params={
+                **self.get_default_params(),
+                'sort': f'-{SUPPORTED_PAPER_SORT_FIELD_1}'
+            }
+        )
+        response.raise_for_status()
+        get_paper_search_response_dict_mock.assert_called()
+        _, kwargs = get_paper_search_response_dict_mock.call_args
+        assert kwargs['sort_parameters'] == (
+            get_opensearch_sort_parameters_for_api_paper_sort_field_list(
+                [f'-{SUPPORTED_PAPER_SORT_FIELD_1}']
+            )
+        )
 
     def test_should_raise_error_for_invalid_sort_field_name(
         self,


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/940

The new `sort` parameter can be left blank, meaning sort by score descending.
It could be `-publication_date` for sorting by publication date in descending order, or `publication_date` to sort by publication date in ascending order.