### PR TITLE
Preprints search filter by publication date

### DIFF
--- a/sciety_labs/app/routers/api/papers/router.py
+++ b/sciety_labs/app/routers/api/papers/router.py
@@ -414,6 +414,7 @@ def create_api_papers_router(
         evaluated_only: bool = fastapi.Query(alias='filter[evaluated_only]', default=False),
         from_publication_date_str: Optional[str] = fastapi.Query(
             alias='filter[publication_date][gte]',
+            description='From publication date in ISO format: YYYY-MM-DD',
             pattern=r'^\d{4}-\d{2}-\d{2}$',
             default=None
         ),

--- a/sciety_labs/app/routers/api/papers/router.py
+++ b/sciety_labs/app/routers/api/papers/router.py
@@ -411,6 +411,10 @@ def create_api_papers_router(
         query: str = fastapi.Query(min_length=3),
         category: Optional[str] = fastapi.Query(alias='filter[category]', default=None),
         evaluated_only: bool = fastapi.Query(alias='filter[evaluated_only]', default=False),
+        _min_publication_date: Optional[str] = fastapi.Query(
+            alias='filter[publication_date][gte]',
+            default=None
+        ),
         page_size: int = fastapi.Query(alias='page[size]', default=10),
         page_number: int = fastapi.Query(alias='page[number]', ge=1, default=1),
         api_paper_fields_csv: str = PAPER_FIELDS_FASTAPI_QUERY,

--- a/sciety_labs/app/routers/api/papers/router.py
+++ b/sciety_labs/app/routers/api/papers/router.py
@@ -27,6 +27,7 @@ from sciety_labs.providers.opensearch.utils import (
     OpenSearchSortField,
     OpenSearchSortParameters
 )
+from sciety_labs.utils.datetime import parse_date_or_none
 from sciety_labs.utils.fastapi import get_cache_control_headers_for_request
 from sciety_labs.utils.text import parse_csv
 
@@ -411,7 +412,7 @@ def create_api_papers_router(
         query: str = fastapi.Query(min_length=3),
         category: Optional[str] = fastapi.Query(alias='filter[category]', default=None),
         evaluated_only: bool = fastapi.Query(alias='filter[evaluated_only]', default=False),
-        _min_publication_date: Optional[str] = fastapi.Query(
+        from_publication_date_str: Optional[str] = fastapi.Query(
             alias='filter[publication_date][gte]',
             pattern=r'^\d{4}-\d{2}-\d{2}$',
             default=None
@@ -440,7 +441,10 @@ def create_api_papers_router(
             .get_paper_search_response_dict(
                 filter_parameters=OpenSearchFilterParameters(
                     category=category,
-                    evaluated_only=evaluated_only
+                    evaluated_only=evaluated_only,
+                    from_publication_date=parse_date_or_none(
+                        from_publication_date_str
+                    )
                 ),
                 sort_parameters=(
                     get_opensearch_sort_parameters_for_api_paper_sort_field_list(

--- a/sciety_labs/app/routers/api/papers/router.py
+++ b/sciety_labs/app/routers/api/papers/router.py
@@ -413,6 +413,7 @@ def create_api_papers_router(
         evaluated_only: bool = fastapi.Query(alias='filter[evaluated_only]', default=False),
         _min_publication_date: Optional[str] = fastapi.Query(
             alias='filter[publication_date][gte]',
+            pattern=r'^\d{4}-\d{2}-\d{2}$',
             default=None
         ),
         page_size: int = fastapi.Query(alias='page[size]', default=10),

--- a/sciety_labs/providers/opensearch/utils.py
+++ b/sciety_labs/providers/opensearch/utils.py
@@ -51,6 +51,7 @@ DEFAULT_PAGE_SIZE = 10
 class OpenSearchFilterParameters:
     evaluated_only: bool = False
     category: Optional[str] = None
+    from_publication_date: Optional[date] = None
 
 
 @dataclasses.dataclass(frozen=True)

--- a/sciety_labs/providers/opensearch/utils.py
+++ b/sciety_labs/providers/opensearch/utils.py
@@ -113,6 +113,10 @@ def get_opensearch_filter_dicts_for_filter_parameters(
         ])
     if filter_parameters.evaluated_only:
         filter_dicts.append(IS_EVALUATED_OPENSEARCH_FILTER_DICT)
+    if filter_parameters.from_publication_date:
+        filter_dicts.append(get_from_publication_date_query_filter(
+            filter_parameters.from_publication_date
+        ))
     return filter_dicts
 
 

--- a/tests/unit_tests/app/routers/api/papers/providers_test.py
+++ b/tests/unit_tests/app/routers/api/papers/providers_test.py
@@ -1,3 +1,4 @@
+from datetime import date
 from unittest.mock import AsyncMock, MagicMock
 
 import opensearchpy
@@ -26,7 +27,8 @@ from sciety_labs.providers.opensearch.utils import (
     OpenSearchPaginationParameters,
     OpenSearchSortField,
     OpenSearchSortParameters,
-    get_category_as_crossref_group_title_opensearch_filter_dict
+    get_category_as_crossref_group_title_opensearch_filter_dict,
+    get_from_publication_date_query_filter
 )
 
 
@@ -133,6 +135,19 @@ class TestGetPaperSearchByCategoryOpenSearchQueryDict:
             IS_BIORXIV_MEDRXIV_DOI_PREFIX_OPENSEARCH_FILTER_DICT,
             get_category_as_crossref_group_title_opensearch_filter_dict('Category 1'),
             IS_EVALUATED_OPENSEARCH_FILTER_DICT
+        ]
+
+    def test_should_include_from_publication_date_filter(self):
+        from_publication_date = date.fromisoformat('2001-02-03')
+        query_dict = get_paper_search_by_category_opensearch_query_dict(
+            filter_parameters=OpenSearchFilterParameters(
+                from_publication_date=from_publication_date
+            ),
+            sort_parameters=OpenSearchSortParameters(),
+            pagination_parameters=OpenSearchPaginationParameters()
+        )
+        assert query_dict['query']['bool']['filter'] == [
+            get_from_publication_date_query_filter(from_publication_date)
         ]
 
     def test_should_be_able_to_sort_by_latest_evaluation_activity(self):

--- a/tests/unit_tests/app/routers/api/papers/router_test.py
+++ b/tests/unit_tests/app/routers/api/papers/router_test.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from datetime import date
 import logging
 from typing import Iterator
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -406,3 +407,22 @@ class TestPapersSearchApiRouterPreprints(_BaseTestPapersApiRouterPreprints):
                 query_parameter_name='sort'
             )
         )
+
+    def test_should_pass_from_publication_date_filter_to_provider(
+        self,
+        get_paper_search_response_dict_mock: AsyncMock,
+        test_client: TestClient
+    ):
+        get_paper_search_response_dict_mock.return_value = (
+            PAPER_SEARCH_RESPONSE_DICT_1
+        )
+        test_client.get(
+            self.get_url(),
+            params={
+                **self.get_default_params(),
+                'filter[publication_date][gte]': '2001-02-03'
+            }
+        )
+        _, kwargs = get_paper_search_response_dict_mock.call_args
+        filter_parameters: OpenSearchFilterParameters = kwargs['filter_parameters']
+        assert filter_parameters.from_publication_date == date.fromisoformat('2001-02-03')


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/940

This allows the search to be filtered by a from publication date: `filter[publication_date][gte]`