### PR TITLE
Use latest evaluation publication timestamp in categories articles RSS feed

### DIFF
--- a/sciety_labs/app/routers/categories.py
+++ b/sciety_labs/app/routers/categories.py
@@ -17,7 +17,7 @@ from sciety_labs.app.utils.common import (
 from sciety_labs.app.utils.response import AtomResponse
 from sciety_labs.models.article import ArticleSearchResultItem
 from sciety_labs.providers.papers.async_papers import PageNumberBasedPaginationParameters
-from sciety_labs.utils.datetime import get_date_as_utc_timestamp, get_utcnow
+from sciety_labs.utils.datetime import get_utcnow
 from sciety_labs.utils.pagination import get_url_pagination_state_for_pagination_parameters
 
 
@@ -27,14 +27,17 @@ LOGGER = logging.getLogger(__name__)
 def get_rss_updated_timestamp(
     search_result_list_with_article_meta: Sequence[ArticleSearchResultItem]
 ) -> Union[date, datetime]:
-    publication_dates = [
-        article_mention.article_meta.published_date
+    latest_evaluation_publication_timestamps = [
+        article_mention.article_stats.latest_evaluation_publication_timestamp
         for article_mention in search_result_list_with_article_meta
-        if article_mention.article_meta and article_mention.article_meta.published_date
+        if (
+            article_mention.article_stats
+            and article_mention.article_stats.latest_evaluation_publication_timestamp
+        )
     ]
-    if not publication_dates:
+    if not latest_evaluation_publication_timestamps:
         return get_utcnow()
-    return get_date_as_utc_timestamp(max(publication_dates))
+    return max(latest_evaluation_publication_timestamps)
 
 
 def create_categories_router(

--- a/sciety_labs/models/article.py
+++ b/sciety_labs/models/article.py
@@ -107,6 +107,7 @@ class ArticleMetaData(NamedTuple):
 
 class ArticleStats(NamedTuple):
     evaluation_count: int = 0
+    latest_evaluation_publication_timestamp: Optional[datetime] = None
 
 
 class ArticleAuthor(NamedTuple):

--- a/sciety_labs/providers/papers/async_papers.py
+++ b/sciety_labs/providers/papers/async_papers.py
@@ -7,9 +7,9 @@ from sciety_labs.app.routers.api.papers.typing import (
     PaperDict,
     PaperSearchResponseDict
 )
-from sciety_labs.models.article import ArticleMetaData, ArticleSearchResultItem
+from sciety_labs.models.article import ArticleMetaData, ArticleSearchResultItem, ArticleStats
 from sciety_labs.providers.utils.async_requests_provider import AsyncRequestsProvider
-from sciety_labs.utils.datetime import parse_date_or_none
+from sciety_labs.utils.datetime import parse_date_or_none, parse_timestamp_or_none
 
 
 LOGGER = logging.getLogger(__name__)
@@ -48,13 +48,28 @@ def get_search_result_item_for_paper_dict(
     LOGGER.debug('paper_dict: %r', paper_dict)
     paper_attributes_dict = paper_dict['attributes']
     doi = paper_attributes_dict['doi']
+    evaluation_count = paper_attributes_dict.get('evaluation_count')
+    latest_evaluation_activity_timestamp_str = (
+        paper_attributes_dict.get('latest_evaluation_activity_timestamp')
+    )
+    article_stats = (
+        ArticleStats(
+            evaluation_count=evaluation_count,
+            latest_evaluation_publication_timestamp=parse_timestamp_or_none(
+                latest_evaluation_activity_timestamp_str
+            )
+        )
+        if evaluation_count
+        else None
+    )
     return ArticleSearchResultItem(
         article_doi=doi,
         article_meta=ArticleMetaData(
             article_doi=doi,
             article_title=paper_attributes_dict.get('title'),
             published_date=parse_date_or_none(paper_attributes_dict.get('publication_date'))
-        )
+        ),
+        article_stats=article_stats
     )
 
 

--- a/sciety_labs/providers/sql/get_sciety_events.sql
+++ b/sciety_labs/providers/sql/get_sciety_events.sql
@@ -6,6 +6,7 @@ SELECT
   event.sciety_group,
   event.article_id,
   event.evaluation_locator,
+  event.published_at_timestamp,
   event.content
 FROM `elife-data-pipeline.prod.v_sciety_event` AS event
 WHERE NOT event.is_duplicate_event

--- a/sciety_labs/utils/datetime.py
+++ b/sciety_labs/utils/datetime.py
@@ -8,6 +8,12 @@ def parse_timestamp(timestamp_str: str) -> datetime:
     return datetime.fromisoformat(timestamp_str)
 
 
+def parse_timestamp_or_none(timestamp_str: Optional[str]) -> Optional[datetime]:
+    if not timestamp_str:
+        return None
+    return parse_timestamp(timestamp_str)
+
+
 def parse_date_or_none(date_str: Optional[str]) -> Optional[date]:
     if not date_str:
         return None

--- a/templates/pages/categories-articles.atom.xml
+++ b/templates/pages/categories-articles.atom.xml
@@ -12,7 +12,7 @@
         <title type="html">{{ item.article_meta.article_title_or_placeholder }}</title>
         <link href="https://sciety.org/articles/activity/{{ item.article_doi }}?utm_source=sciety_labs_atom_feed" />
         <published>{{ item.article_meta.published_date | date_isoformat }}T00:00:00+00:00</published>
-        <updated>{{ item.article_meta.published_date | date_isoformat }}T00:00:00+00:00</updated>
+        <updated>{{ item.article_stats.latest_evaluation_publication_timestamp | timestamp_isoformat }}</updated>
         <id>tag:sciety-labs,2023-04-20:doi={{ item.article_doi }}</id>
         {{- render_atom_content_for_article_mention(item) }}
         {{- render_atom_authors_for_article_meta(item.article_meta) }}

--- a/tests/unit_tests/models/evaluation_test.py
+++ b/tests/unit_tests/models/evaluation_test.py
@@ -1,19 +1,27 @@
+from datetime import datetime
 from sciety_labs.models.evaluation import ScietyEventEvaluationStatsModel
 from sciety_labs.models.sciety_event import ScietyEventNames
 
 
-ARTICLE_ID_1 = 'doi:10.1234/doi_1'
-ARTICLE_ID_2 = 'doi:10.1234/doi_2'
+DOI_1 = '10.1234/doi_1'
+DOI_2 = '10.1234/doi_2'
+
+ARTICLE_ID_1 = f'doi:{DOI_1}'
+ARTICLE_ID_2 = f'doi:{DOI_2}'
 
 EVALUATION_LOCATOR_1 = 'test:evaluation_1'
 EVALUATION_LOCATOR_2 = 'test:evaluation_2'
 EVALUATION_LOCATOR_3 = 'test:evaluation_3'
 
+TIMESTAMP_1 = datetime.fromisoformat('2001-02-03T00:00:01+00:00')
+TIMESTAMP_2 = datetime.fromisoformat('2001-02-03T00:00:02+00:00')
+
 
 EVALUATION_RECORDED_EVENT_1 = {
     'event_name': ScietyEventNames.EVALUATION_PUBLICATION_RECORDED,
     'article_id': ARTICLE_ID_1,
-    'evaluation_locator': EVALUATION_LOCATOR_1
+    'evaluation_locator': EVALUATION_LOCATOR_1,
+    'published_at_timestamp': TIMESTAMP_1
 }
 
 
@@ -89,6 +97,23 @@ class TestScietyEventEvaluationStatsModel:
             'article_id': None
         }])
         assert model.get_evaluation_count_by_article_id(ARTICLE_ID_1) == 0
+
+    def test_should_return_latest_evaluation_timestamp(self):
+        model = ScietyEventEvaluationStatsModel([{
+            **EVALUATION_RECORDED_EVENT_1,
+            'article_id': ARTICLE_ID_1,
+            'evaluation_locator': EVALUATION_LOCATOR_1,
+            'published_at_timestamp': TIMESTAMP_2
+        }, {
+            **EVALUATION_RECORDED_EVENT_1,
+            'article_id': ARTICLE_ID_1,
+            'evaluation_locator': EVALUATION_LOCATOR_2,
+            'published_at_timestamp': TIMESTAMP_1
+        }])
+        assert (
+            model.get_article_stats_by_article_doi(DOI_1).latest_evaluation_publication_timestamp
+            == TIMESTAMP_2
+        )
 
     def test_should_not_count_evaluation_twice_on_apply_events(self):
         sciety_events = [EVALUATION_RECORDED_EVENT_1]

--- a/tests/unit_tests/providers/papers/async_papers_test.py
+++ b/tests/unit_tests/providers/papers/async_papers_test.py
@@ -196,7 +196,7 @@ class TestAsyncPapersProviderCategoryDisplayNameList:
 
 class TestAsyncPapersProviderPreprints:
     @pytest.mark.asyncio
-    async def test_should_pass_cateogry_and_evaluated_only_as_filter_and_set_fields(
+    async def test_should_pass_category_and_evaluated_only_as_filter_and_set_fields(
         self,
         async_papers_provider: AsyncPapersProvider,
         response_mock: AsyncMock,

--- a/tests/unit_tests/providers/papers/async_papers_test.py
+++ b/tests/unit_tests/providers/papers/async_papers_test.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 import logging
 from unittest.mock import AsyncMock, MagicMock
 
@@ -23,6 +23,9 @@ LOGGER = logging.getLogger(__name__)
 
 
 DOI_1 = '10.12345/doi_1'
+
+
+TIMESTAMP_1 = datetime.fromisoformat('2001-02-03T00:00:01+00:00')
 
 
 PAGINATION_PARAMETERS_1 = PageNumberBasedPaginationParameters(
@@ -153,6 +156,25 @@ class TestGetSearchResultListItemsForPaperSearchResponseDict:
         assert item.article_meta.article_doi == DOI_1
         assert item.article_meta.article_title == 'Title 1'
         assert item.article_meta.published_date == date.fromisoformat('2001-02-03')
+
+    def test_should_parse_search_response_with_article_stats(self):
+        items = get_search_result_list_items_for_paper_search_response_dict({
+            'data': [{
+                'id': 'some_id',
+                'type': 'paper',
+                'attributes': {
+                    'doi': DOI_1,
+                    'title': 'Title 1',
+                    'evaluation_count': 3,
+                    'latest_evaluation_activity_timestamp': TIMESTAMP_1.isoformat()
+                }
+            }]
+        })
+        assert len(items) == 1
+        item = items[0]
+        assert item.article_doi == DOI_1
+        assert item.article_stats.evaluation_count == 3
+        assert item.article_stats.latest_evaluation_publication_timestamp == TIMESTAMP_1
 
 
 class TestGetSearchResultListForPaperSearchResponseDict:


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/948

This is to ensure a more accurate updated timestamp that matches the sort order.