### PR TITLE
Use search input type

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -249,6 +249,10 @@
     margin-bottom: 1em;
 }
 
+.search-form__submit {
+    display: inline-block;
+}
+
 .search-browse-categories-link-container {
     float: right;
 }
@@ -265,10 +269,6 @@
 
 section.article-stats {
     margin-top: 0.5em;
-}
-
-.search-form__submit {
-    display: inline-block;
 }
 
 /* htmx-request */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -253,6 +253,10 @@
     display: inline-block;
 }
 
+.search-form__text {
+    padding-right: 0.75em;
+}
+
 .search-browse-categories-link-container {
     float: right;
 }

--- a/templates/pages/search.html
+++ b/templates/pages/search.html
@@ -19,7 +19,7 @@
                     Search articles by DOI, author or keyword
                 </div>
                 <div class="search-form__positioning_context">
-                    <input value="{{ query }}" id="searchText" name="query" minlength="{{ min_query_length }}" class="search-form__text">
+                    <input value="{{ query }}" id="searchText" name="query" type="search" minlength="{{ min_query_length }}" class="search-form__text">
                     <section class="search-form__section">
                         {{ render_checkbox_with_label(name='evaluated_only', label='Search only evaluated articles', label_class='search-form__checkbox_label', is_checked=is_search_evaluated_only) }}
                     </section>
@@ -50,9 +50,6 @@
                     </section>
                     <button type="submit" class="search-form__submit" aria-label="Run the search">Search</button>
                     <button formaction="/feeds/search/create" type="submit" class="secondary-action-button search-form__create-feed" aria-label="Create feed">Create feed</button>
-                    <button type="reset" id="clearSearchText" class="search-form__clear">
-                        <img src="/static/sciety/images/clear-search-text-icon.svg" class="search-form__clear_icon" alt="">
-                    </button>
                     <div class="search-browse-categories-link-container">
                         Or
                         <a href="/categories">Browse Categories</a>


### PR DESCRIPTION
For Chromium based browsers that will add a clear input button on hover.
As a consequence removed our reset button that was styled like one but didn't work in Sciety Labs.