### PR TITLE
Delete expired non-async http cache responses

### DIFF
--- a/sciety_labs/app/app_providers_and_models.py
+++ b/sciety_labs/app/app_providers_and_models.py
@@ -169,6 +169,7 @@ class AppProvidersAndModels:  # pylint: disable=too-many-instance-attributes
             allowable_methods=('GET', 'HEAD', 'POST'),  # include POST for Semantic Scholar
             match_headers=False
         )
+        self.cached_requests_session = cached_requests_session
 
         async_connector = aiohttp.TCPConnector(limit=1000)
 

--- a/sciety_labs/app/app_providers_and_models.py
+++ b/sciety_labs/app/app_providers_and_models.py
@@ -165,7 +165,7 @@ class AppProvidersAndModels:  # pylint: disable=too-many-instance-attributes
 
         cached_requests_session = requests_cache.CachedSession(
             '.cache/requests_cache',
-            xpire_after=timedelta(days=1),
+            expire_after=timedelta(days=1),
             allowable_methods=('GET', 'HEAD', 'POST'),  # include POST for Semantic Scholar
             match_headers=False
         )

--- a/sciety_labs/app/app_update_manager.py
+++ b/sciety_labs/app/app_update_manager.py
@@ -11,7 +11,11 @@ class AppUpdateManager:
     def __init__(self, app_providers_and_models: AppProvidersAndModels):
         self.app_providers_and_models = app_providers_and_models
 
-    def check_or_reload_data(self, preload_only: bool = False):
+    def check_or_reload_data(
+        self,
+        preload_only: bool = False,
+        delete_exired: bool = True
+    ):
         if not preload_only:
             self.app_providers_and_models.sciety_event_provider.refresh()
         # Note: this may still use a cache
@@ -26,6 +30,9 @@ class AppUpdateManager:
         else:
             self.app_providers_and_models.google_sheet_article_image_provider.refresh()
             self.app_providers_and_models.google_sheet_list_image_provider.refresh()
+        if delete_exired:
+            LOGGER.info('Deleting expired requests-cache responses')
+            self.app_providers_and_models.cached_requests_session.cache.delete(expired=True)
 
     def check_or_reload_data_no_fail(self):
         try:


### PR DESCRIPTION
Related to https://github.com/elifesciences/data-hub-issues/issues/954

Also fixes expiry for non-async cache.