### PR TITLE
Install google-cloud-bigquery-storage for faster BigQuery access

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ bleach==6.1.0
 fastapi==0.112.0
 google-api-python-client==2.139.0
 google-cloud-bigquery==3.25.0
+google-cloud-bigquery-storage==2.25.0
 Jinja2==3.1.4
 lxml==5.2.2
 objsize==0.7.0


### PR DESCRIPTION
This is to avoid the following warning:

> 2024-08-05 13:56:04,951 - INFO - p:240091/t:Thread-3/l:sciety_labs.providers.utils.bigquery_provider - Loading Sciety Event query results from BigQuery...
> /home/deuser/_git_/elife/sciety/sciety-labs/venv/lib/python3.9/site-packages/google/cloud/bigquery/table.py:1727: UserWarning: BigQuery Storage module not found, fetch data with the REST endpoint instead.
>  warnings.warn(