### PR TITLE
Extended preprint server support for search by searching over calculated title and abstract fields

### DIFF
--- a/sciety_labs/app/routers/api/papers/providers.py
+++ b/sciety_labs/app/routers/api/papers/providers.py
@@ -53,8 +53,8 @@ INTERNAL_ARTICLE_FIELDS_BY_API_FIELD_NAME: Mapping[str, Sequence[str]] = {
 
 DEFAULT_OPENSEARCH_SEARCH_FIELDS = [
     'doi',
-    'europepmc.title_with_markup',
-    'europepmc.abstract_with_markup'
+    'calculated.title_with_markup',
+    'calculated.abstract_with_markup'
 ]
 
 


### PR DESCRIPTION
part of https://github.com/elifesciences/data-hub-issues/issues/963

This searches over the calculated title and abstract fields instead of data from EuropePMC only.